### PR TITLE
Avoid using thread locals for tracking cpu interrupts.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,18 +1166,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum_dispatch"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
-dependencies = [
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3797,7 +3785,6 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "dirs",
- "enum_dispatch",
  "flate2",
  "image",
  "rand 0.10.0",

--- a/tetanes-core/src/apu.rs
+++ b/tetanes-core/src/apu.rs
@@ -13,7 +13,7 @@ use crate::{
         triangle::Triangle,
     },
     common::{Clock, ClockTo, NesRegion, Regional, Reset, ResetKind, Sample},
-    cpu::{Cpu, Irq},
+    cpu::{Cpu, CpuInterrupts, Irq},
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -66,18 +66,18 @@ impl TryFrom<usize> for Channel {
 
 /// Trait for [`Apu`] registers.
 pub trait ApuRegisters {
-    fn write_ctrl(&mut self, channel: Channel, val: u8);
-    fn write_sweep(&mut self, channel: Channel, val: u8);
-    fn write_timer_lo(&mut self, channel: Channel, val: u8);
-    fn write_timer_hi(&mut self, channel: Channel, val: u8);
-    fn write_linear_counter(&mut self, val: u8);
-    fn write_length(&mut self, channel: Channel, val: u8);
-    fn write_dmc_output(&mut self, val: u8);
-    fn write_dmc_addr(&mut self, val: u8);
-    fn read_status(&mut self) -> u8;
+    fn write_ctrl(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts);
+    fn write_sweep(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts);
+    fn write_timer_lo(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts);
+    fn write_timer_hi(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts);
+    fn write_linear_counter(&mut self, val: u8, intrs: &mut CpuInterrupts);
+    fn write_length(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts);
+    fn write_dmc_output(&mut self, val: u8, intrs: &mut CpuInterrupts);
+    fn write_dmc_addr(&mut self, val: u8, intrs: &mut CpuInterrupts);
+    fn read_status(&mut self, intrs: &mut CpuInterrupts) -> u8;
     fn peek_status(&self) -> u8;
-    fn write_status(&mut self, val: u8);
-    fn write_frame_counter(&mut self, val: u8);
+    fn write_status(&mut self, val: u8, intrs: &mut CpuInterrupts);
+    fn write_frame_counter(&mut self, val: u8, intrs: &mut CpuInterrupts);
 }
 
 /// NES APU (Audio Processing Unit).
@@ -242,18 +242,18 @@ impl Apu {
         }
     }
 
-    pub fn clock_lazy(&mut self) {
+    pub fn clock_lazy(&mut self, intrs: &mut CpuInterrupts) {
         self.cpu_cycle = self.cpu_cycle.wrapping_add(1);
         self.master_cycle += 1;
         if self.master_cycle == Self::CYCLE_SIZE - 1 {
-            self.clock_flush();
-        } else if self.should_clock() {
-            self.clock_to(self.master_cycle);
+            self.clock_flush(intrs);
+        } else if self.should_clock(intrs) {
+            self.clock_to(self.master_cycle, intrs);
         }
     }
 
-    pub fn clock_flush(&mut self) {
-        self.clock_to(self.master_cycle);
+    pub fn clock_flush(&mut self, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
 
         self.process_outputs();
 
@@ -267,10 +267,10 @@ impl Apu {
         self.dmc.timer.cycle = 0;
     }
 
-    fn should_clock(&mut self) -> bool {
+    fn should_clock(&mut self, intrs: &mut CpuInterrupts) -> bool {
         // Clock every cycle while DMC is running to get accurate CPU stalling, sprite DMA
         // emulation, etc
-        if self.dmc.should_clock() || self.should_clock {
+        if self.dmc.should_clock(intrs) || self.should_clock {
             self.should_clock = false;
             return true;
         }
@@ -278,13 +278,19 @@ impl Apu {
         self.frame_counter.should_clock(cycles) || self.dmc.irq_pending_in(cycles)
     }
 
-    fn channel_clock_to(&mut self, channel: Channel, cycle: u32) {
-        fn clock_to<T>(instance: &mut T, cycle: u32, offset: usize, outputs: &mut [f32])
+    fn channel_clock_to(&mut self, channel: Channel, cycle: u32, intrs: &mut CpuInterrupts) {
+        fn clock_to<T>(
+            instance: &mut T,
+            cycle: u32,
+            offset: usize,
+            outputs: &mut [f32],
+            intrs: &mut CpuInterrupts,
+        )
         where
             T: Clock + TimerCycle + Sample,
         {
             while instance.cycle() < cycle {
-                instance.clock();
+                instance.clock(intrs);
                 outputs[((instance.cycle() - 1) as usize * Apu::MAX_CHANNEL_COUNT) + offset] =
                     instance.output();
             }
@@ -293,18 +299,47 @@ impl Apu {
         let offset = channel as usize;
         let outputs = &mut self.channel_outputs;
         match channel {
-            Channel::Pulse1 => clock_to(&mut self.pulse1, cycle, offset, outputs),
-            Channel::Pulse2 => clock_to(&mut self.pulse2, cycle, offset, outputs),
-            Channel::Triangle => clock_to(&mut self.triangle, cycle, offset, outputs),
-            Channel::Noise => clock_to(&mut self.noise, cycle, offset, outputs),
-            Channel::Dmc => clock_to(&mut self.dmc, cycle, offset, outputs),
+            Channel::Pulse1 => clock_to(&mut self.pulse1, cycle, offset, outputs, intrs),
+            Channel::Pulse2 => clock_to(&mut self.pulse2, cycle, offset, outputs, intrs),
+            Channel::Triangle => clock_to(&mut self.triangle, cycle, offset, outputs, intrs),
+            Channel::Noise => clock_to(&mut self.noise, cycle, offset, outputs, intrs),
+            Channel::Dmc => clock_to(&mut self.dmc, cycle, offset, outputs, intrs),
             _ => (),
         }
+    }
+
+    fn status(&self, intrs: Option<&CpuInterrupts>) -> u8 {
+        let mut status = 0x00;
+        if self.pulse1.length.counter > 0 {
+            status |= 0x01;
+        }
+        if self.pulse2.length.counter > 0 {
+            status |= 0x02;
+        }
+        if self.triangle.length.counter > 0 {
+            status |= 0x04;
+        }
+        if self.noise.length.counter > 0 {
+            status |= 0x08;
+        }
+        if self.dmc.bytes_remaining > 0 {
+            trace!("dmc bytes remaining: {}", self.dmc.bytes_remaining);
+            status |= 0x10;
+        }
+        if let Some(intrs) = intrs {
+            if intrs.has_irq(Irq::FRAME_COUNTER) {
+                status |= 0x40;
+            }
+            if intrs.has_irq(Irq::DMC) {
+                status |= 0x80;
+            }
+        }
+        status
     }
 }
 
 impl ClockTo for Apu {
-    fn clock_to(&mut self, cycle: u32) {
+    fn clock_to(&mut self, cycle: u32, intrs: &mut CpuInterrupts) {
         self.master_cycle = cycle;
 
         let cycles = self.master_cycle - self.cycle;
@@ -315,20 +350,20 @@ impl ClockTo for Apu {
         while self.master_cycle - self.cycle > 0 {
             self.cycle += self
                 .frame_counter
-                .clock_with(self.master_cycle - self.cycle, |ty| match ty {
+                .clock_with(self.master_cycle - self.cycle, intrs, |ty, intrs| match ty {
                     FrameType::Quarter => {
                         trace!("APU Quarter Frame clock - CYC:{}", self.cpu_cycle);
-                        self.pulse1.clock_quarter_frame();
-                        self.pulse2.clock_quarter_frame();
-                        self.triangle.clock_quarter_frame();
-                        self.noise.clock_quarter_frame();
+                        self.pulse1.clock_quarter_frame(intrs);
+                        self.pulse2.clock_quarter_frame(intrs);
+                        self.triangle.clock_quarter_frame(intrs);
+                        self.noise.clock_quarter_frame(intrs);
                     }
                     FrameType::Half => {
                         trace!("APU Half Frame clock - CYC:{}", self.cpu_cycle);
-                        self.pulse1.clock_half_frame();
-                        self.pulse2.clock_half_frame();
-                        self.triangle.clock_half_frame();
-                        self.noise.clock_half_frame();
+                        self.pulse1.clock_half_frame(intrs);
+                        self.pulse2.clock_half_frame(intrs);
+                        self.triangle.clock_half_frame(intrs);
+                        self.noise.clock_half_frame(intrs);
                     }
                     _ => (),
                 });
@@ -338,11 +373,11 @@ impl ClockTo for Apu {
             self.triangle.length.reload();
             self.noise.length.reload();
 
-            self.channel_clock_to(Channel::Pulse1, self.cycle);
-            self.channel_clock_to(Channel::Pulse2, self.cycle);
-            self.channel_clock_to(Channel::Triangle, self.cycle);
-            self.channel_clock_to(Channel::Noise, self.cycle);
-            self.channel_clock_to(Channel::Dmc, self.cycle);
+            self.channel_clock_to(Channel::Pulse1, self.cycle, intrs);
+            self.channel_clock_to(Channel::Pulse2, self.cycle, intrs);
+            self.channel_clock_to(Channel::Triangle, self.cycle, intrs);
+            self.channel_clock_to(Channel::Noise, self.cycle, intrs);
+            self.channel_clock_to(Channel::Dmc, self.cycle, intrs);
         }
     }
 }
@@ -355,8 +390,8 @@ impl Default for Apu {
 
 impl ApuRegisters for Apu {
     /// $4000 Pulse1, $4004 Pulse2, and $400C Noise Control.
-    fn write_ctrl(&mut self, channel: Channel, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_ctrl(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         match channel {
             Channel::Pulse1 => {
                 trace!("APU $4000 write: ${val:02X} - CYC:{}", self.cpu_cycle);
@@ -376,8 +411,8 @@ impl ApuRegisters for Apu {
     }
 
     /// $4001 Pulse1 and $4005 Pulse2 Sweep.
-    fn write_sweep(&mut self, channel: Channel, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_sweep(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         match channel {
             Channel::Pulse1 => {
                 trace!("APU $4001 write: ${val:02X} - CYC:{}", self.cpu_cycle);
@@ -392,8 +427,8 @@ impl ApuRegisters for Apu {
     }
 
     /// $4002 Pulse1, $4006 Pulse2, $400A Triangle, $400E Noise, and $4010 DMC Timer Low Byte.
-    fn write_timer_lo(&mut self, channel: Channel, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_timer_lo(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         match channel {
             Channel::Pulse1 => {
                 trace!("APU $4002 write: ${val:02X} - CYC:{}", self.cpu_cycle);
@@ -413,15 +448,15 @@ impl ApuRegisters for Apu {
             }
             Channel::Dmc => {
                 trace!("APU $4010 write: ${val:02X} - CYC:{}", self.cpu_cycle);
-                self.dmc.write_timer(val);
+                self.dmc.write_timer(val, intrs);
             }
             _ => panic!("{channel:?} does not have a timer_lo register"),
         }
     }
 
     /// $4003 Pulse1, $4007 Pulse2, and $400B Triangle Timer High Byte.
-    fn write_timer_hi(&mut self, channel: Channel, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_timer_hi(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         match channel {
             Channel::Pulse1 => {
                 trace!("APU $4003 write: ${val:02X} - CYC:{}", self.cpu_cycle);
@@ -443,16 +478,16 @@ impl ApuRegisters for Apu {
     }
 
     /// $4008 Triangle Linear Counter.
-    fn write_linear_counter(&mut self, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_linear_counter(&mut self, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         trace!("APU $4008 write: ${val:02X} - CYC:{}", self.cpu_cycle);
         self.triangle.write_linear_counter(val);
         self.should_clock = true;
     }
 
     /// $400F Noise and $4013 DMC Length.
-    fn write_length(&mut self, channel: Channel, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_length(&mut self, channel: Channel, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         trace!("APU $400F write: ${val:02X} - CYC:{}", self.cpu_cycle);
         match channel {
             Channel::Noise => {
@@ -465,8 +500,8 @@ impl ApuRegisters for Apu {
     }
 
     /// $4011 DMC Output Level.
-    fn write_dmc_output(&mut self, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_dmc_output(&mut self, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         trace!("APU $4011 write: ${val:02X} - CYC:{}", self.cpu_cycle);
         // Only 7-bits are used
         self.dmc.write_output(val & 0x7F);
@@ -477,8 +512,8 @@ impl ApuRegisters for Apu {
     }
 
     /// $4012 DMC Sample Addr.
-    fn write_dmc_addr(&mut self, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_dmc_addr(&mut self, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         trace!("APU $4012 write: ${val:02X} - CYC:{}", self.cpu_cycle);
         self.dmc.write_addr(val);
     }
@@ -486,14 +521,14 @@ impl ApuRegisters for Apu {
     /// Read APU Status.
     ///
     /// $4015   if-d nt21   DMC IRQ, frame IRQ, length counter statuses
-    fn read_status(&mut self) -> u8 {
-        self.clock_to(self.master_cycle);
-        let val = self.peek_status();
+    fn read_status(&mut self, intrs: &mut CpuInterrupts) -> u8 {
+        self.clock_to(self.master_cycle, intrs);
+        let val = self.status(Some(intrs));
         trace!("APU $4015 read: ${val:02X} - CYC:{}", self.cpu_cycle);
-        if Cpu::has_irq(Irq::FRAME_COUNTER) {
+        if intrs.has_irq(Irq::FRAME_COUNTER) {
             trace!("APU Frame Counter IRQ - CYC:{}", self.cpu_cycle);
         }
-        Cpu::clear_irq(Irq::FRAME_COUNTER);
+        self.frame_counter.clear_irq(intrs);
         val
     }
 
@@ -501,40 +536,16 @@ impl ApuRegisters for Apu {
     ///
     /// Non-mutating version of `read_status`.
     fn peek_status(&self) -> u8 {
-        let mut status = 0x00;
-        if self.pulse1.length.counter > 0 {
-            status |= 0x01;
-        }
-        if self.pulse2.length.counter > 0 {
-            status |= 0x02;
-        }
-        if self.triangle.length.counter > 0 {
-            status |= 0x04;
-        }
-        if self.noise.length.counter > 0 {
-            status |= 0x08;
-        }
-        if self.dmc.bytes_remaining > 0 {
-            trace!("dmc bytes remaining: {}", self.dmc.bytes_remaining);
-            status |= 0x10;
-        }
-        let irqs = Cpu::irqs();
-        if irqs.contains(Irq::FRAME_COUNTER) {
-            status |= 0x40;
-        }
-        if irqs.contains(Irq::DMC) {
-            status |= 0x80;
-        }
-        status
+        self.status(None)
     }
 
     /// Write APU Status.
     ///
     /// $4015   ---d nt21   length ctr enable: DMC, noise, triangle, pulse 2, 1
-    fn write_status(&mut self, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_status(&mut self, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         trace!("APU $4015 write: ${val:02X} - CYC:{}", self.cpu_cycle);
-        Cpu::clear_irq(Irq::DMC);
+        self.dmc.clear_irq(intrs);
         self.pulse1.set_enabled(val & 0x01 == 0x01);
         self.pulse2.set_enabled(val & 0x02 == 0x02);
         self.triangle.set_enabled(val & 0x04 == 0x04);
@@ -543,10 +554,14 @@ impl ApuRegisters for Apu {
     }
 
     /// $4017 APU Frame Counter.
-    fn write_frame_counter(&mut self, val: u8) {
-        self.clock_to(self.master_cycle);
+    fn write_frame_counter(&mut self, val: u8, intrs: &mut CpuInterrupts) {
+        self.clock_to(self.master_cycle, intrs);
         trace!("APU $4017 write: ${val:02X} - CYC:{}", self.cpu_cycle);
         self.frame_counter.write(val, self.cpu_cycle);
+        if self.frame_counter.inhibit_irq {
+            trace!("APU Frame Counter IRQ inhibit");
+            self.frame_counter.clear_irq(intrs);
+        }
     }
 }
 
@@ -555,32 +570,32 @@ impl Regional for Apu {
         self.region
     }
 
-    fn set_region(&mut self, region: NesRegion) {
+    fn set_region(&mut self, region: NesRegion, intrs: &mut CpuInterrupts) {
         if self.region != region {
-            self.clock_to(self.master_cycle);
+            self.clock_to(self.master_cycle, intrs);
             self.region = region;
             self.clock_rate = Cpu::region_clock_rate(region);
             self.filter_chain = FilterChain::new(region, self.sample_rate);
             self.sample_period = self.clock_rate / self.sample_rate;
             self.frame_counter.set_region(region);
-            self.noise.set_region(region);
-            self.dmc.set_region(region);
+            self.noise.set_region(region, intrs);
+            self.dmc.set_region(region, intrs);
         }
     }
 }
 
 impl Reset for Apu {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
         self.cpu_cycle = 0;
         self.master_cycle = 0;
         self.cycle = 0;
         self.should_clock = false;
-        self.frame_counter.reset(kind);
-        self.pulse1.reset(kind);
-        self.pulse2.reset(kind);
-        self.triangle.reset(kind);
-        self.noise.reset(kind);
-        self.dmc.reset(kind);
+        self.frame_counter.reset(kind, intrs);
+        self.pulse1.reset(kind, intrs);
+        self.pulse2.reset(kind, intrs);
+        self.triangle.reset(kind, intrs);
+        self.noise.reset(kind, intrs);
+        self.dmc.reset(kind, intrs);
     }
 }
 

--- a/tetanes-core/src/apu/dmc.rs
+++ b/tetanes-core/src/apu/dmc.rs
@@ -5,7 +5,7 @@
 use crate::{
     apu::timer::{Timer, TimerCycle},
     common::{Clock, NesRegion, Regional, Reset, ResetKind, Sample},
-    cpu::{Cpu, Irq},
+    cpu::{CpuInterrupts, Irq},
 };
 use serde::{Deserialize, Serialize};
 use tracing::trace;
@@ -106,7 +106,7 @@ impl Dmc {
         self.should_clock = self.bytes_remaining > 0;
     }
 
-    pub fn load_buffer(&mut self, val: u8) {
+    pub fn load_buffer(&mut self, val: u8, intrs: &mut CpuInterrupts) {
         if self.bytes_remaining > 0 {
             self.sample_buffer = val;
             self.buffer_empty = false;
@@ -122,7 +122,7 @@ impl Dmc {
                 if self.loops {
                     self.init_sample();
                 } else if self.irq_enabled {
-                    Cpu::set_irq(Irq::DMC);
+                    intrs.set_irq(Irq::DMC);
                 }
             }
         }
@@ -139,12 +139,12 @@ impl Dmc {
     }
 
     /// $4010 DMC timer
-    pub fn write_timer(&mut self, val: u8) {
+    pub fn write_timer(&mut self, val: u8, intrs: &mut CpuInterrupts) {
         self.irq_enabled = val & 0x80 == 0x80;
         self.loops = val & 0x40 == 0x40;
         self.timer.period = Self::period(self.region, val);
         if !self.irq_enabled {
-            Cpu::clear_irq(Irq::DMC);
+            self.clear_irq(intrs);
         }
     }
 
@@ -175,12 +175,16 @@ impl Dmc {
         }
     }
 
-    pub fn should_clock(&mut self) -> bool {
+    pub fn clear_irq(&mut self, intrs: &mut CpuInterrupts) {
+        intrs.clear_irq(Irq::DMC);
+    }
+
+    pub fn should_clock(&mut self, intrs: &mut CpuInterrupts) -> bool {
         if self.init > 0 {
             self.init -= 1;
             if self.init == 0 && self.buffer_empty && self.bytes_remaining > 0 {
                 trace!("APU DMC DMA pending");
-                Cpu::start_dmc_dma();
+                intrs.start_dmc_dma();
             }
         }
         self.should_clock
@@ -208,7 +212,7 @@ impl Clock for Dmc {
     //                            |
     //                            v
     // Reader ---> Buffer ---> Shifter ---> Output level ---> (to the mixer)
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut CpuInterrupts) {
         if self.timer.tick() {
             if !self.silence {
                 // Update output level but clamp to 0..=127 range
@@ -235,7 +239,7 @@ impl Clock for Dmc {
                     self.buffer_empty = true;
                     if self.bytes_remaining > 0 {
                         trace!("APU DMC DMA pending");
-                        Cpu::start_dmc_dma();
+                        intrs.start_dmc_dma();
                     }
                 }
             }
@@ -248,15 +252,15 @@ impl Regional for Dmc {
         self.region
     }
 
-    fn set_region(&mut self, region: NesRegion) {
+    fn set_region(&mut self, region: NesRegion, _intrs: &mut CpuInterrupts) {
         self.region = region;
         self.timer.period = Self::period(region, 0);
     }
 }
 
 impl Reset for Dmc {
-    fn reset(&mut self, kind: ResetKind) {
-        self.timer.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
+        self.timer.reset(kind, intrs);
         self.timer.period = Self::period(self.region, 0);
         self.timer.reload();
         self.timer.cycle += 1; // FIXME: Startup timing is slightly wrong, DMA tests fail with the
@@ -276,5 +280,6 @@ impl Reset for Dmc {
         self.shift = 0x00;
         self.silence = true;
         self.should_clock = false;
+        intrs.clear_irq(Irq::DMC);
     }
 }

--- a/tetanes-core/src/apu/envelope.rs
+++ b/tetanes-core/src/apu/envelope.rs
@@ -56,7 +56,7 @@ impl Envelope {
 }
 
 impl Clock for Envelope {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.start {
             self.start = false;
             self.counter = 15;
@@ -75,7 +75,7 @@ impl Clock for Envelope {
 }
 
 impl Reset for Envelope {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.start = false;
         self.constant_volume = false;
         self.volume = 0;

--- a/tetanes-core/src/apu/frame_counter.rs
+++ b/tetanes-core/src/apu/frame_counter.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     common::{NesRegion, Reset, ResetKind},
-    cpu::{Cpu, Irq},
+    cpu::{CpuInterrupts, Irq},
 };
 use serde::{Deserialize, Serialize};
 use tracing::trace;
@@ -86,10 +86,10 @@ impl FrameCounter {
         self.write_delay = if cycle & 0x01 == 0x01 { 4 } else { 3 };
         trace!("APU $4017 write delay cycles: {}", self.write_delay);
         self.inhibit_irq = val & 0x40 == 0x40; // D6
-        if self.inhibit_irq {
-            trace!("APU Frame Counter IRQ inhibit");
-            Cpu::clear_irq(Irq::FRAME_COUNTER);
-        }
+    }
+
+    pub fn clear_irq(&mut self, intrs: &mut CpuInterrupts) {
+        intrs.clear_irq(Irq::FRAME_COUNTER);
     }
 
     pub const fn should_clock(&mut self, cycles: u32) -> bool {
@@ -109,7 +109,12 @@ impl FrameCounter {
     // - - - - - -     (interrupt flag never set)
     // - l - - l -     96 Hz
     // e e e - e -     192 Hz
-    pub fn clock_with(&mut self, cycles: u32, mut on_clock: impl FnMut(FrameType)) -> u32 {
+    pub fn clock_with(
+        &mut self,
+        cycles: u32,
+        intrs: &mut CpuInterrupts,
+        mut on_clock: impl FnMut(FrameType, &mut CpuInterrupts),
+    ) -> u32 {
         let mut cycles_ran = 0;
         let step_cycles = self.step_cycles[self.step];
         if self.cycle + cycles >= step_cycles {
@@ -118,12 +123,12 @@ impl FrameCounter {
                     "APU Frame Counter IRQ pending - cycles: {} >= {step_cycles}",
                     self.cycle + cycles
                 );
-                Cpu::set_irq(Irq::FRAME_COUNTER);
+                intrs.set_irq(Irq::FRAME_COUNTER);
             }
 
             let ty = Self::FRAME_TYPE[self.step];
             if ty != FrameType::None && self.block_counter == 0 {
-                on_clock(ty);
+                on_clock(ty, intrs);
                 // Do not allow writes to $4017 to clock for the next cycle (odd + following even
                 // cycle)
                 self.block_counter = 2;
@@ -157,9 +162,13 @@ impl FrameCounter {
                 self.step = 0;
                 self.cycle = 0;
                 self.write_buffer = None;
+                if self.inhibit_irq {
+                    trace!("APU Frame Counter IRQ inhibit");
+                    self.clear_irq(intrs);
+                }
                 if self.mode == 1 && self.block_counter == 0 {
                     // Writing to $4017 with bit 7 set will immediately generate a quarter/half frame
-                    on_clock(FrameType::Half);
+                    on_clock(FrameType::Half, intrs);
                     self.block_counter = 2;
                 }
             }
@@ -174,8 +183,9 @@ impl FrameCounter {
 }
 
 impl Reset for FrameCounter {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
         self.cycle = 0;
+        intrs.clear_irq(Irq::FRAME_COUNTER);
         if kind == ResetKind::Hard {
             self.mode = 0;
             self.step_cycles = Self::step_cycles(self.mode, self.region);

--- a/tetanes-core/src/apu/length_counter.rs
+++ b/tetanes-core/src/apu/length_counter.rs
@@ -75,7 +75,7 @@ impl LengthCounter {
 }
 
 impl Clock for LengthCounter {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.counter > 0 && !self.halt {
             self.counter -= 1;
         }
@@ -83,7 +83,7 @@ impl Clock for LengthCounter {
 }
 
 impl Reset for LengthCounter {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.enabled = false;
         match kind {
             ResetKind::Soft => {

--- a/tetanes-core/src/apu/noise.rs
+++ b/tetanes-core/src/apu/noise.rs
@@ -87,13 +87,13 @@ impl Noise {
         }
     }
 
-    pub fn clock_quarter_frame(&mut self) {
-        self.envelope.clock();
+    pub fn clock_quarter_frame(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.envelope.clock(intrs);
     }
 
-    pub fn clock_half_frame(&mut self) {
-        self.clock_quarter_frame();
-        self.length.clock();
+    pub fn clock_half_frame(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.clock_quarter_frame(intrs);
+        self.length.clock(intrs);
     }
 
     /// $400C Noise control
@@ -152,7 +152,7 @@ impl Clock for Noise {
     //                    |                |
     //                    v                v
     // Envelope -------> Gate ----------> Gate --> (to mixer)
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.timer.tick() {
             let shift_by = if self.shift_mode == ShiftMode::One {
                 6
@@ -171,17 +171,17 @@ impl Regional for Noise {
         self.region
     }
 
-    fn set_region(&mut self, region: NesRegion) {
+    fn set_region(&mut self, region: NesRegion, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.region = region;
     }
 }
 
 impl Reset for Noise {
-    fn reset(&mut self, kind: ResetKind) {
-        self.timer.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.timer.reset(kind, intrs);
         self.timer.period = Self::period(self.region, 0);
-        self.length.reset(kind);
-        self.envelope.reset(kind);
+        self.length.reset(kind, intrs);
+        self.envelope.reset(kind, intrs);
         self.shift = 1;
         self.shift_mode = ShiftMode::Zero;
     }

--- a/tetanes-core/src/apu/pulse.rs
+++ b/tetanes-core/src/apu/pulse.rs
@@ -131,13 +131,13 @@ impl Pulse {
         }
     }
 
-    pub fn clock_quarter_frame(&mut self) {
-        self.envelope.clock();
+    pub fn clock_quarter_frame(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.envelope.clock(intrs);
     }
 
-    pub fn clock_half_frame(&mut self) {
-        self.clock_quarter_frame();
-        self.length.clock();
+    pub fn clock_half_frame(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.clock_quarter_frame(intrs);
+        self.length.clock(intrs);
         self.clock_sweep();
     }
 
@@ -212,7 +212,7 @@ impl Clock for Pulse {
     //                    |            |             |
     //                    v            v             v
     // Envelope -------> Gate -----> Gate -------> Gate --->(to mixer)
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.timer.tick() {
             self.duty_cycle = self.duty_cycle.wrapping_sub(1) & 0x07;
         }
@@ -220,11 +220,11 @@ impl Clock for Pulse {
 }
 
 impl Reset for Pulse {
-    fn reset(&mut self, kind: ResetKind) {
-        self.timer.reset(kind);
-        self.length.reset(kind);
-        self.envelope.reset(kind);
-        self.sweep.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.timer.reset(kind, intrs);
+        self.length.reset(kind, intrs);
+        self.envelope.reset(kind, intrs);
+        self.sweep.reset(kind, intrs);
         self.update_target_period();
         self.duty = 0;
         self.duty_cycle = 0;
@@ -264,7 +264,7 @@ impl Sweep {
 }
 
 impl Reset for Sweep {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.enabled = false;
         self.period = 0;
         self.negate = false;

--- a/tetanes-core/src/apu/timer.rs
+++ b/tetanes-core/src/apu/timer.rs
@@ -49,7 +49,7 @@ impl Timer {
 }
 
 impl Reset for Timer {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.counter = 0;
         self.period = 0;
         self.cycle = 0;

--- a/tetanes-core/src/apu/triangle.rs
+++ b/tetanes-core/src/apu/triangle.rs
@@ -56,13 +56,13 @@ impl Triangle {
         self.force_silent = silent;
     }
 
-    pub fn clock_quarter_frame(&mut self) {
-        self.linear.clock();
+    pub fn clock_quarter_frame(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.linear.clock(intrs);
     }
 
-    pub fn clock_half_frame(&mut self) {
-        self.clock_quarter_frame();
-        self.length.clock();
+    pub fn clock_half_frame(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.clock_quarter_frame(intrs);
+        self.length.clock(intrs);
     }
 
     /// $4008 Linear counter control
@@ -114,7 +114,7 @@ impl Clock for Triangle {
     //             |                |
     //             v                v
     // Timer ---> Gate ----------> Gate ---> Sequencer ---> (to mixer)
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.timer.tick() && self.length.counter > 0 && self.linear.counter > 0 {
             self.sequence = (self.sequence + 1) & 0x1F;
         }
@@ -122,9 +122,9 @@ impl Clock for Triangle {
 }
 
 impl Reset for Triangle {
-    fn reset(&mut self, kind: ResetKind) {
-        self.length.reset(kind);
-        self.linear.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.length.reset(kind, intrs);
+        self.linear.reset(kind, intrs);
         self.sequence = 0;
     }
 }
@@ -157,7 +157,7 @@ impl LinearCounter {
 }
 
 impl Clock for LinearCounter {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.reload {
             self.counter = self.counter_reload;
         } else if self.counter > 0 {
@@ -170,7 +170,7 @@ impl Clock for LinearCounter {
 }
 
 impl Reset for LinearCounter {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.counter = 0;
         self.counter_reload = 0;
         self.reload = false;

--- a/tetanes-core/src/bus.rs
+++ b/tetanes-core/src/bus.rs
@@ -6,7 +6,7 @@ use crate::{
     apu::{Apu, ApuRegisters, Channel},
     cart::Cart,
     common::{Clock, ClockTo, NesRegion, Regional, Reset, ResetKind, Sample, Sram},
-    cpu::Cpu,
+    cpu::CpuInterrupts,
     fs,
     genie::GenieCode,
     input::{Input, InputRegisters, Player},
@@ -162,8 +162,8 @@ impl Bus {
 }
 
 impl Clock for Bus {
-    fn clock(&mut self) {
-        self.ppu.bus.mapper.clock();
+    fn clock(&mut self, intrs: &mut CpuInterrupts) {
+        self.ppu.bus.mapper.clock(intrs);
         let output = match self.ppu.bus.mapper {
             Mapper::Exrom(ref exrom) => exrom.output(),
             Mapper::Namco163(ref namco163) => namco163.output(),
@@ -172,23 +172,23 @@ impl Clock for Bus {
             _ => 0.0,
         };
         self.apu.add_mapper_output(output);
-        self.apu.clock_lazy();
-        self.input.clock();
+        self.apu.clock_lazy(intrs);
+        self.input.clock(intrs);
     }
 }
 
 impl ClockTo for Bus {
-    fn clock_to(&mut self, clock: u32) {
-        self.ppu.clock_to(clock);
+    fn clock_to(&mut self, clock: u32, intrs: &mut CpuInterrupts) {
+        self.ppu.clock_to(clock, intrs);
     }
 }
 
 impl Read for Bus {
-    fn read(&mut self, addr: u16) -> u8 {
+    fn read(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> u8 {
         let val = match addr {
             0x0000..=0x07FF => self.wram[addr as usize],
             0x4020..=0xFFFF => {
-                let val = match self.ppu.bus.mapper.map_read(addr) {
+                let val = match self.ppu.bus.mapper.map_read(addr, intrs) {
                     MappedRead::Data(val) => val,
                     MappedRead::PrgRam(addr) => self.prg_ram[addr],
                     MappedRead::PrgRom(addr) => self.prg_rom[addr],
@@ -196,19 +196,19 @@ impl Read for Bus {
                 };
                 self.genie_read(addr, val)
             }
-            0x2002 => self.ppu.read_status(),
+            0x2002 => self.ppu.read_status(intrs),
             0x2004 => self.ppu.read_oamdata(),
-            0x2007 => self.ppu.read_data(),
-            0x4015 => self.apu.read_status(),
+            0x2007 => self.ppu.read_data(intrs),
+            0x4015 => self.apu.read_status(intrs),
             0x4016 => self.input.read(Player::One, &self.ppu),
             0x4017 => self.input.read(Player::Two, &self.ppu),
             0x2000 | 0x2001 | 0x2003 | 0x2005 | 0x2006 => self.ppu.open_bus,
-            0x0800..=0x1FFF => self.read(addr & 0x07FF), // WRAM Mirrors
-            0x2008..=0x3FFF => self.read(addr & 0x2007), // Ppu Mirrors
+            0x0800..=0x1FFF => self.read(addr & 0x07FF, intrs), // WRAM Mirrors
+            0x2008..=0x3FFF => self.read(addr & 0x2007, intrs), // Ppu Mirrors
             _ => self.open_bus,
         };
         self.open_bus = val;
-        self.ppu.bus.mapper.bus_read(addr, BusKind::Cpu);
+        self.ppu.bus.mapper.bus_read(addr, BusKind::Cpu, intrs);
         val
     }
 
@@ -239,12 +239,12 @@ impl Read for Bus {
 }
 
 impl Write for Bus {
-    fn write(&mut self, addr: u16, val: u8) {
+    fn write(&mut self, addr: u16, val: u8, intrs: &mut CpuInterrupts) {
         match addr {
             0x0000..=0x07FF => {
                 self.wram[addr as usize] = val;
             }
-            0x4020..=0xFFFF => match self.ppu.bus.mapper.map_write(addr, val) {
+            0x4020..=0xFFFF => match self.ppu.bus.mapper.map_write(addr, val, intrs) {
                 MappedWrite::PrgRam(addr, val) => {
                     if !self.prg_ram.is_empty() && !self.prg_ram_protect {
                         self.prg_ram[addr] = val;
@@ -253,42 +253,42 @@ impl Write for Bus {
                 MappedWrite::PrgRamProtect(protect) => self.prg_ram_protect = protect,
                 _ => (),
             },
-            0x2000 => self.ppu.write_ctrl(val),
+            0x2000 => self.ppu.write_ctrl(val, intrs),
             0x2001 => self.ppu.write_mask(val),
             0x2003 => self.ppu.write_oamaddr(val),
             0x2004 => self.ppu.write_oamdata(val),
             0x2005 => self.ppu.write_scroll(val),
-            0x2006 => self.ppu.write_addr(val),
-            0x2007 => self.ppu.write_data(val),
-            0x4000 => self.apu.write_ctrl(Channel::Pulse1, val),
-            0x4001 => self.apu.write_sweep(Channel::Pulse1, val),
-            0x4002 => self.apu.write_timer_lo(Channel::Pulse1, val),
-            0x4003 => self.apu.write_timer_hi(Channel::Pulse1, val),
-            0x4004 => self.apu.write_ctrl(Channel::Pulse2, val),
-            0x4005 => self.apu.write_sweep(Channel::Pulse2, val),
-            0x4006 => self.apu.write_timer_lo(Channel::Pulse2, val),
-            0x4007 => self.apu.write_timer_hi(Channel::Pulse2, val),
-            0x4008 => self.apu.write_linear_counter(val),
-            0x400A => self.apu.write_timer_lo(Channel::Triangle, val),
-            0x400B => self.apu.write_timer_hi(Channel::Triangle, val),
-            0x400C => self.apu.write_ctrl(Channel::Noise, val),
-            0x400E => self.apu.write_timer_lo(Channel::Noise, val),
-            0x400F => self.apu.write_length(Channel::Noise, val),
-            0x4010 => self.apu.write_timer_lo(Channel::Dmc, val),
-            0x4011 => self.apu.write_dmc_output(val),
-            0x4012 => self.apu.write_dmc_addr(val),
-            0x4013 => self.apu.write_length(Channel::Dmc, val),
-            0x4014 => Cpu::start_oam_dma(u16::from(val) << 8),
-            0x4015 => self.apu.write_status(val),
+            0x2006 => self.ppu.write_addr(val, intrs),
+            0x2007 => self.ppu.write_data(val, intrs),
+            0x4000 => self.apu.write_ctrl(Channel::Pulse1, val, intrs),
+            0x4001 => self.apu.write_sweep(Channel::Pulse1, val, intrs),
+            0x4002 => self.apu.write_timer_lo(Channel::Pulse1, val, intrs),
+            0x4003 => self.apu.write_timer_hi(Channel::Pulse1, val, intrs),
+            0x4004 => self.apu.write_ctrl(Channel::Pulse2, val, intrs),
+            0x4005 => self.apu.write_sweep(Channel::Pulse2, val, intrs),
+            0x4006 => self.apu.write_timer_lo(Channel::Pulse2, val, intrs),
+            0x4007 => self.apu.write_timer_hi(Channel::Pulse2, val, intrs),
+            0x4008 => self.apu.write_linear_counter(val, intrs),
+            0x400A => self.apu.write_timer_lo(Channel::Triangle, val, intrs),
+            0x400B => self.apu.write_timer_hi(Channel::Triangle, val, intrs),
+            0x400C => self.apu.write_ctrl(Channel::Noise, val, intrs),
+            0x400E => self.apu.write_timer_lo(Channel::Noise, val, intrs),
+            0x400F => self.apu.write_length(Channel::Noise, val, intrs),
+            0x4010 => self.apu.write_timer_lo(Channel::Dmc, val, intrs),
+            0x4011 => self.apu.write_dmc_output(val, intrs),
+            0x4012 => self.apu.write_dmc_addr(val, intrs),
+            0x4013 => self.apu.write_length(Channel::Dmc, val, intrs),
+            0x4014 => intrs.start_oam_dma(u16::from(val) << 8),
+            0x4015 => self.apu.write_status(val, intrs),
             0x4016 => self.input.write(val),
-            0x4017 => self.apu.write_frame_counter(val),
+            0x4017 => self.apu.write_frame_counter(val, intrs),
             0x2002 => self.ppu.open_bus = val,
-            0x0800..=0x1FFF => return self.write(addr & 0x07FF, val), // WRAM Mirrors
-            0x2008..=0x3FFF => return self.write(addr & 0x2007, val), // Ppu Mirrors
+            0x0800..=0x1FFF => return self.write(addr & 0x07FF, val, intrs), // WRAM Mirrors
+            0x2008..=0x3FFF => return self.write(addr & 0x2007, val, intrs), // Ppu Mirrors
             _ => (),
         }
         self.open_bus = val;
-        self.ppu.bus.mapper.bus_write(addr, val, BusKind::Cpu);
+        self.ppu.bus.mapper.bus_write(addr, val, BusKind::Cpu, intrs);
     }
 }
 
@@ -297,22 +297,22 @@ impl Regional for Bus {
         self.region
     }
 
-    fn set_region(&mut self, region: NesRegion) {
+    fn set_region(&mut self, region: NesRegion, intrs: &mut CpuInterrupts) {
         self.region = region;
-        self.ppu.set_region(region);
-        self.apu.set_region(region);
+        self.ppu.set_region(region, intrs);
+        self.apu.set_region(region, intrs);
         self.input.set_region(region);
     }
 }
 
 impl Reset for Bus {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
         if kind == ResetKind::Hard {
             self.ram_state.fill(&mut **self.wram);
             self.ram_state.fill(&mut self.prg_ram);
         }
-        self.ppu.reset(kind);
-        self.apu.reset(kind);
+        self.ppu.reset(kind, intrs);
+        self.apu.reset(kind, intrs);
     }
 }
 
@@ -370,24 +370,25 @@ mod test {
         cart.mapper = Cnrom::load(&mut cart).unwrap();
         bus.load_cart(cart);
 
-        bus.write(0x2006, 0x00);
-        bus.write(0x2006, 0x00);
-        bus.read(0x2007);
-        assert_eq!(bus.read(0x2007), 0x66, "chr_rom start");
-        bus.write(0x2006, 0x1F);
-        bus.write(0x2006, 0xFF);
-        bus.read(0x2007);
-        assert_eq!(bus.read(0x2007), 0x66, "chr_rom end");
+        let mut intrs = CpuInterrupts::default();
+        bus.write(0x2006, 0x00, &mut intrs);
+        bus.write(0x2006, 0x00, &mut intrs);
+        bus.read(0x2007, &mut intrs);
+        assert_eq!(bus.read(0x2007, &mut intrs), 0x66, "chr_rom start");
+        bus.write(0x2006, 0x1F, &mut intrs);
+        bus.write(0x2006, 0xFF, &mut intrs);
+        bus.read(0x2007, &mut intrs);
+        assert_eq!(bus.read(0x2007, &mut intrs), 0x66, "chr_rom end");
 
         // Writes disallowed
-        bus.write(0x2006, 0x00);
-        bus.write(0x2006, 0x10);
-        bus.write(0x2007, 0x77);
+        bus.write(0x2006, 0x00, &mut intrs);
+        bus.write(0x2006, 0x10, &mut intrs);
+        bus.write(0x2007, 0x77, &mut intrs);
 
-        bus.write(0x2006, 0x00);
-        bus.write(0x2006, 0x10);
-        bus.read(0x2007);
-        assert_eq!(bus.read(0x2007), 0x66, "chr_rom read-only");
+        bus.write(0x2006, 0x00, &mut intrs);
+        bus.write(0x2006, 0x10, &mut intrs);
+        bus.read(0x2007, &mut intrs);
+        assert_eq!(bus.read(0x2007, &mut intrs), 0x66, "chr_rom read-only");
     }
 
     #[test]
@@ -399,30 +400,31 @@ mod test {
         cart.mapper = Nrom::load(&mut cart).unwrap();
         bus.load_cart(cart);
 
-        bus.write(0x2006, 0x00);
-        bus.write(0x2006, 0x00);
-        bus.read(0x2007);
-        assert_eq!(bus.read(0x2007), 0x66, "chr_ram start");
-        bus.write(0x2006, 0x1F);
-        bus.write(0x2006, 0xFF);
-        bus.read(0x2007);
-        assert_eq!(bus.read(0x2007), 0x66, "chr_ram end");
+        let mut intrs = CpuInterrupts::default();
+        bus.write(0x2006, 0x00, &mut intrs);
+        bus.write(0x2006, 0x00, &mut intrs);
+        bus.read(0x2007, &mut intrs);
+        assert_eq!(bus.read(0x2007, &mut intrs), 0x66, "chr_ram start");
+        bus.write(0x2006, 0x1F, &mut intrs);
+        bus.write(0x2006, 0xFF, &mut intrs);
+        bus.read(0x2007, &mut intrs);
+        assert_eq!(bus.read(0x2007, &mut intrs), 0x66, "chr_ram end");
 
         // Writes allowed
-        bus.write(0x2006, 0x10);
-        bus.write(0x2006, 0x00);
+        bus.write(0x2006, 0x10, &mut intrs);
+        bus.write(0x2006, 0x00, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        bus.ppu.clock();
-        bus.ppu.clock();
-        bus.write(0x2007, 0x77);
+        bus.ppu.clock(&mut intrs);
+        bus.ppu.clock(&mut intrs);
+        bus.write(0x2007, 0x77, &mut intrs);
 
-        bus.write(0x2006, 0x10);
-        bus.write(0x2006, 0x00);
+        bus.write(0x2006, 0x10, &mut intrs);
+        bus.write(0x2006, 0x00, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        bus.ppu.clock();
-        bus.ppu.clock();
-        bus.read(0x2007);
-        assert_eq!(bus.read(0x2007), 0x77, "chr_ram write");
+        bus.ppu.clock(&mut intrs);
+        bus.ppu.clock(&mut intrs);
+        bus.read(0x2007, &mut intrs);
+        assert_eq!(bus.read(0x2007, &mut intrs), 0x77, "chr_ram write");
     }
 
     #[test]
@@ -441,20 +443,22 @@ mod test {
         bus.load_cart(cart);
         bus.add_genie_code(GenieCode::new(code.to_string()).expect("valid genie code"));
 
+        let mut intrs = CpuInterrupts::default();
         assert_eq!(bus.peek(addr), new_value, "peek code value");
-        assert_eq!(bus.read(addr), new_value, "read code value");
+        assert_eq!(bus.read(addr, &mut intrs), new_value, "read code value");
         bus.remove_genie_code(code);
         assert_eq!(bus.peek(addr), orig_value, "peek orig value");
-        assert_eq!(bus.read(addr), orig_value, "read orig value");
+        assert_eq!(bus.read(addr, &mut intrs), orig_value, "read orig value");
     }
 
     #[test]
     fn clock() {
         let mut bus = Bus::default();
 
-        bus.clock_to(12);
+        let mut intrs = CpuInterrupts::default();
+        bus.clock_to(12, &mut intrs);
         assert_eq!(bus.ppu.master_clock, 12, "ppu clock");
-        bus.clock();
+        bus.clock(&mut intrs);
         assert_eq!(bus.apu.master_cycle, 1, "apu clock");
     }
 
@@ -462,22 +466,23 @@ mod test {
     fn read_write_ram() {
         let mut bus = Bus::default();
 
-        bus.write(0x0001, 0x66);
+        let mut intrs = CpuInterrupts::default();
+        bus.write(0x0001, 0x66, &mut intrs);
         assert_eq!(bus.peek(0x0001), 0x66, "peek ram");
-        assert_eq!(bus.read(0x0001), 0x66, "read ram");
-        assert_eq!(bus.read(0x0801), 0x66, "peek mirror 1");
-        assert_eq!(bus.read(0x0801), 0x66, "read mirror 1");
-        assert_eq!(bus.read(0x1001), 0x66, "peek mirror 2");
-        assert_eq!(bus.read(0x1001), 0x66, "read mirror 2");
-        assert_eq!(bus.read(0x1801), 0x66, "peek mirror 3");
-        assert_eq!(bus.read(0x1801), 0x66, "read mirror 3");
+        assert_eq!(bus.read(0x0001, &mut intrs), 0x66, "read ram");
+        assert_eq!(bus.read(0x0801, &mut intrs), 0x66, "peek mirror 1");
+        assert_eq!(bus.read(0x0801, &mut intrs), 0x66, "read mirror 1");
+        assert_eq!(bus.read(0x1001, &mut intrs), 0x66, "peek mirror 2");
+        assert_eq!(bus.read(0x1001, &mut intrs), 0x66, "read mirror 2");
+        assert_eq!(bus.read(0x1801, &mut intrs), 0x66, "peek mirror 3");
+        assert_eq!(bus.read(0x1801, &mut intrs), 0x66, "read mirror 3");
 
-        bus.write(0x0802, 0x77);
-        assert_eq!(bus.read(0x0002), 0x77, "write mirror 1");
-        bus.write(0x1002, 0x88);
-        assert_eq!(bus.read(0x0002), 0x88, "write mirror 2");
-        bus.write(0x1802, 0x99);
-        assert_eq!(bus.read(0x0002), 0x99, "write mirror 3");
+        bus.write(0x0802, 0x77, &mut intrs);
+        assert_eq!(bus.read(0x0002, &mut intrs), 0x77, "write mirror 1");
+        bus.write(0x1002, 0x88, &mut intrs);
+        assert_eq!(bus.read(0x0002, &mut intrs), 0x88, "write mirror 2");
+        bus.write(0x1802, 0x99, &mut intrs);
+        assert_eq!(bus.read(0x0002, &mut intrs), 0x99, "write mirror 3");
     }
 
     #[test]

--- a/tetanes-core/src/cart.rs
+++ b/tetanes-core/src/cart.rs
@@ -418,7 +418,7 @@ impl Regional for Cart {
         self.region
     }
 
-    fn set_region(&mut self, region: NesRegion) {
+    fn set_region(&mut self, region: NesRegion, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.region = region;
     }
 }

--- a/tetanes-core/src/common.rs
+++ b/tetanes-core/src/common.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Write, path::Path};
 use thiserror::Error;
 
+use crate::cpu::CpuInterrupts;
+
 /// Default directory for save states.
 pub const SAVE_DIR: &str = "save";
 /// Default directory for save RAM.
@@ -133,7 +135,7 @@ pub trait Regional {
     }
 
     /// Set the region.
-    fn set_region(&mut self, _region: NesRegion) {}
+    fn set_region(&mut self, _region: NesRegion, _intrs: &mut CpuInterrupts) {}
 }
 
 /// Type of reset for types that have different behavior for reset vs power cycling.
@@ -149,19 +151,19 @@ pub enum ResetKind {
 /// Trait for types that can can be reset.
 pub trait Reset {
     /// Reset the component given the [`ResetKind`].
-    fn reset(&mut self, _kind: ResetKind) {}
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut CpuInterrupts) {}
 }
 
 /// Trait for types that can be clocked.
 pub trait Clock {
     /// Clock component once.
-    fn clock(&mut self) {}
+    fn clock(&mut self, _intrs: &mut CpuInterrupts) {}
 }
 
 /// Trait for types that can clock to a target cycle.
 pub trait ClockTo {
     /// Clock component to the given master_cycle.
-    fn clock_to(&mut self, _master_cycle: u32) {}
+    fn clock_to(&mut self, _master_cycle: u32, _intrs: &mut CpuInterrupts) {}
 }
 
 /// Trait for types that can output `f32` audio samples.
@@ -242,7 +244,7 @@ pub fn hexdump(data: &[u8], addr_offset: usize) -> Vec<String> {
 pub(crate) mod tests {
     use crate::{
         action::Action,
-        common::{Regional, Reset, ResetKind},
+        common::{Reset, ResetKind},
         control_deck::{Config, ControlDeck},
         input::Player,
         mem::RamState,
@@ -489,8 +491,12 @@ pub(crate) mod tests {
                 if deck.frame_number() != test_frame.number && !test_frame.audio {
                     deck.clear_audio_samples();
                 }
-                deck.joypad_mut(Player::One).reset(ResetKind::Soft);
-                deck.joypad_mut(Player::Two).reset(ResetKind::Soft);
+
+                let (joypad, intrs) = deck.joypad_mut_with_interrupts(Player::One);
+                joypad.reset(ResetKind::Soft, intrs);
+
+                let (joypad, intrs) = deck.joypad_mut_with_interrupts(Player::Two);
+                joypad.reset(ResetKind::Soft, intrs);
             }
 
             on_frame_action(test_frame, &mut deck);

--- a/tetanes-core/src/control_deck.rs
+++ b/tetanes-core/src/control_deck.rs
@@ -5,7 +5,7 @@ use crate::{
     bus::Bus,
     cart::{self, Cart},
     common::{Clock, NesRegion, Regional, Reset, ResetKind, Sram},
-    cpu::Cpu,
+    cpu::{Cpu, CpuInterrupts, Dma, Irq},
     debug::Debugger,
     fs,
     genie::{self, GenieCode},
@@ -223,6 +223,7 @@ pub struct ControlDeck {
     frame_accumulator: u16,
     /// NES CPU.
     cpu: Cpu,
+    cpu_interrupts: CpuInterrupts
 }
 
 impl Default for ControlDeck {
@@ -240,16 +241,17 @@ impl ControlDeck {
     /// Create a NES `ControlDeck` with a configuration.
     pub fn with_config(cfg: Config) -> Self {
         let mut cpu = Cpu::new(Bus::new(cfg.region, cfg.ram_state));
+        let mut cpu_interrupts = CpuInterrupts::default();
         cpu.bus.ppu.skip_rendering = cfg.headless_mode.contains(HeadlessMode::NO_VIDEO);
         cpu.bus.ppu.emulate_warmup = cfg.emulate_ppu_warmup;
         cpu.bus.apu.skip_mixing = cfg.headless_mode.contains(HeadlessMode::NO_AUDIO);
         if cfg.region.is_auto() {
-            cpu.set_region(NesRegion::Ntsc);
+            cpu.set_region(NesRegion::Ntsc, &mut cpu_interrupts);
         } else {
-            cpu.set_region(cfg.region);
+            cpu.set_region(cfg.region, &mut cpu_interrupts);
         }
         cpu.bus.input.set_concurrent_dpad(cfg.concurrent_dpad);
-        cpu.bus.input.set_four_player(cfg.four_player);
+        cpu.bus.input.set_four_player(cfg.four_player, &mut cpu_interrupts);
         cpu.bus.input.connect_zapper(cfg.zapper);
         for (i, enabled) in cfg.channels_enabled.iter().enumerate() {
             match Channel::try_from(i) {
@@ -273,6 +275,7 @@ impl ControlDeck {
             frame_speed_step: 4,
             frame_accumulator: 0,
             cpu,
+            cpu_interrupts
         }
     }
 
@@ -301,7 +304,7 @@ impl ControlDeck {
             region: cart.region(),
         };
         if self.auto_detect_region {
-            self.cpu.set_region(loaded_rom.region);
+            self.cpu.set_region(loaded_rom.region, &mut self.cpu_interrupts);
         }
         self.cpu.bus.load_cart(cart);
         self.update_mapper_revisions();
@@ -353,6 +356,22 @@ impl ControlDeck {
     #[inline]
     pub fn load_cpu(&mut self, cpu: Cpu) {
         self.cpu.load(cpu);
+    }
+
+    #[inline]
+    fn set_region_inner(&mut self, region: NesRegion) {
+        self.auto_detect_region = region.is_auto();
+        if self.auto_detect_region {
+            self.cpu
+                .set_region(self.cart_region().unwrap_or_default(), &mut self.cpu_interrupts);
+        } else {
+            self.cpu.set_region(region, &mut self.cpu_interrupts);
+        }
+    }
+
+    #[inline]
+    pub fn set_region(&mut self, region: NesRegion) {
+        self.set_region_inner(region);
     }
 
     /// Set the [`MapperRevision`] to emulate for the any ROM loaded that uses this mapper.
@@ -622,6 +641,10 @@ impl ControlDeck {
         self.cpu.clock_rate()
     }
 
+    fn clock(&mut self) {
+        self.cpu.clock(&mut self.cpu_interrupts);
+    }
+
     /// Steps the control deck one CPU clock.
     ///
     /// # Errors
@@ -707,7 +730,7 @@ impl ControlDeck {
                 self.clock_instr()?;
             }
         }
-        self.cpu.bus.apu.clock_flush();
+        self.cpu.bus.apu.clock_flush(&mut self.cpu_interrupts);
 
         Ok(())
     }
@@ -929,7 +952,7 @@ impl ControlDeck {
     /// Enable/Disable Four Score for 4-player controllers.
     #[inline]
     pub fn set_four_player(&mut self, four_player: FourPlayer) {
-        self.cpu.bus.input.set_four_player(four_player);
+        self.cpu.bus.input.set_four_player(four_player, &mut self.cpu_interrupts);
     }
 
     /// Returns the current [`Joypad`] state for a given controller slot.
@@ -942,6 +965,12 @@ impl ControlDeck {
     #[inline]
     pub const fn joypad_mut(&mut self, slot: Player) -> &mut Joypad {
         self.cpu.bus.input.joypad_mut(slot)
+    }
+
+    #[cfg(test)]
+    #[inline]
+    pub(crate) const fn joypad_mut_with_interrupts(&mut self, slot: Player) -> (&mut Joypad, &mut CpuInterrupts) {
+        (self.cpu.bus.input.joypad_mut(slot), &mut self.cpu_interrupts)
     }
 
     /// Returns whether the [`Zapper`](crate::input::Zapper) gun is connected.
@@ -1043,12 +1072,24 @@ impl ControlDeck {
     pub const fn is_running(&self) -> bool {
         self.running
     }
-}
 
-impl Clock for ControlDeck {
-    /// Steps the control deck a single clock cycle.
-    fn clock(&mut self) {
-        self.cpu.clock()
+    /// Resets the console.
+    pub fn reset(&mut self, kind: ResetKind) {
+        self.cpu_interrupts.clear_nmi();
+        self.cpu_interrupts.clear_irq(Irq::all());
+        self.cpu_interrupts.clear_dma_halt();
+        self.cpu_interrupts.clear_dma(Dma::all());
+        self.cpu_interrupts.clear_dma_dummy_read();
+
+        self.cpu.reset(kind, &mut self.cpu_interrupts);
+        if self.loaded_rom.is_some() {
+            self.running = true;
+        }
+    }
+
+    pub fn cpu_interrupts_mut(&mut self) -> &mut CpuInterrupts
+    {
+        &mut self.cpu_interrupts
     }
 }
 
@@ -1059,22 +1100,7 @@ impl Regional for ControlDeck {
     }
 
     /// Set the NES format for the emulation.
-    fn set_region(&mut self, region: NesRegion) {
-        self.auto_detect_region = region.is_auto();
-        if self.auto_detect_region {
-            self.cpu.set_region(self.cart_region().unwrap_or_default());
-        } else {
-            self.cpu.set_region(region);
-        }
-    }
-}
-
-impl Reset for ControlDeck {
-    /// Resets the console.
-    fn reset(&mut self, kind: ResetKind) {
-        self.cpu.reset(kind);
-        if self.loaded_rom.is_some() {
-            self.running = true;
-        }
+    fn set_region(&mut self, region: NesRegion, _intrs: &mut CpuInterrupts) {
+        self.set_region_inner(region);
     }
 }

--- a/tetanes-core/src/cpu.rs
+++ b/tetanes-core/src/cpu.rs
@@ -14,21 +14,123 @@ use crate::{
 };
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
-use std::{
-    cell::Cell,
-    fmt::{self},
-};
+use std::fmt::{self};
 use tracing::trace;
 
 pub mod instr;
 
-thread_local! {
-    static NMI: Cell<bool> = const { Cell::new(false) };
-    static IRQS: Cell<Irq> = const { Cell::new(Irq::empty()) };
-    static DMAS: Cell<Dma> = const { Cell::new(Dma::empty()) };
-    static DMA_HALT: Cell<bool> = const { Cell::new(false) };
-    static DMA_DUMMY_READ: Cell<bool> = const { Cell::new(false) };
-    static DMA_OAM_ADDR: Cell<u16> = const { Cell::new(0x0000) };
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CpuInterrupts {
+    nmi: bool,
+    irqs: Irq,
+    dmas: Dma,
+    dma_halt: bool,
+    dma_dummy_read: bool,
+    dma_oam_addr: u16,
+}
+
+impl Default for CpuInterrupts {
+    fn default() -> Self {
+        Self {
+            nmi: false,
+            irqs: Irq::empty(),
+            dmas: Dma::empty(),
+            dma_halt: false,
+            dma_dummy_read: false,
+            dma_oam_addr: 0,
+        }
+    }
+}
+
+impl CpuInterrupts {
+        #[inline]
+    #[must_use]
+    pub fn nmi_pending(&self) -> bool {
+        self.nmi
+    }
+
+    #[inline]
+    pub fn set_nmi(&mut self) {
+        self.nmi = true;
+    }
+
+    #[inline]
+    pub fn clear_nmi(&mut self) {
+        self.nmi = false;
+    }
+
+    #[inline]
+    pub fn irqs(&self) -> Irq {
+        self.irqs
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn has_irq(&self, irq: Irq) -> bool {
+        self.irqs.contains(irq)
+    }
+
+    #[inline]
+    pub fn set_irq(&mut self, irq: Irq) {
+        self.irqs |= irq;
+    }
+
+    #[inline]
+    pub fn clear_irq(&mut self, irq: Irq) {
+        self.irqs = self.irqs & !irq;
+    }
+
+    #[inline]
+    pub fn start_dmc_dma(&mut self) {
+        self.dmas |= Dma::DMC;
+        self.dma_halt = true;
+        self.dma_dummy_read = true;
+    }
+
+    #[inline]
+    pub fn start_oam_dma(&mut self, addr: u16) {
+        self.dmas |= Dma::OAM;
+        self.dma_halt = true;
+        self.dma_oam_addr = addr;
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn halt_for_dma(&self) -> bool {
+        self.dma_halt
+    }
+
+    #[inline]
+    pub fn dma_oam_addr(&self) -> u16 {
+        self.dma_oam_addr
+    }
+
+    #[inline]
+    #[must_use]
+    pub fn dmas_running(&self) -> Option<(bool, bool)> {
+        let dmas = self.dmas;
+        (!dmas.is_empty()).then_some((dmas.contains(Dma::DMC), dmas.contains(Dma::OAM)))
+    }
+
+    #[inline]
+    pub fn clear_dma(&mut self, dma: Dma) {
+        self.dmas = self.dmas & !dma;
+    }
+
+    #[inline]
+    pub fn clear_dma_halt(&mut self) {
+        self.dma_halt = false;
+    }
+
+    #[inline]
+    pub fn dma_dummy_read(&self) -> bool {
+        self.dma_dummy_read
+    }
+
+    #[inline]
+    pub fn clear_dma_dummy_read(&mut self) {
+        self.dma_dummy_read = false;
+    }
 }
 
 bitflags! {
@@ -114,7 +216,7 @@ pub struct Cpu {
     #[serde(skip)]
     pub corrupted: bool, // Encountering an invalid opcode corrupts CPU processing
     #[serde(skip)]
-    pub disasm: String,
+    pub disasm: String
 }
 
 impl Cpu {
@@ -154,9 +256,10 @@ impl Cpu {
             irq_flags: IrqFlags::default(),
             bus,
             corrupted: false,
-            disasm: String::new(),
+            disasm: String::new()
         };
-        cpu.set_region(cpu.bus.region);
+        let mut intrs = CpuInterrupts::default();
+        cpu.set_region(cpu.bus.region, &mut intrs);
         cpu
     }
 
@@ -200,95 +303,6 @@ impl Cpu {
         Cpu::INSTR_REF[usize::from(opcode)]
     }
 
-    #[inline]
-    #[must_use]
-    pub fn nmi_pending() -> bool {
-        NMI.get()
-    }
-
-    #[inline]
-    pub fn set_nmi() {
-        NMI.set(true);
-    }
-
-    #[inline]
-    pub fn clear_nmi() {
-        NMI.set(false);
-    }
-
-    #[inline]
-    pub fn irqs() -> Irq {
-        IRQS.get()
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn has_irq(irq: Irq) -> bool {
-        IRQS.get().contains(irq)
-    }
-
-    #[inline]
-    pub fn set_irq(irq: Irq) {
-        IRQS.set(IRQS.get() | irq);
-    }
-
-    #[inline]
-    pub fn clear_irq(irq: Irq) {
-        IRQS.set(IRQS.get() & !irq);
-    }
-
-    #[inline]
-    pub fn start_dmc_dma() {
-        DMAS.set(DMAS.get() | Dma::DMC);
-        DMA_HALT.set(true);
-        DMA_DUMMY_READ.set(true);
-    }
-
-    #[inline]
-    pub fn start_oam_dma(addr: u16) {
-        DMAS.set(DMAS.get() | Dma::OAM);
-        DMA_HALT.set(true);
-        DMA_OAM_ADDR.set(addr);
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn halt_for_dma() -> bool {
-        DMA_HALT.get()
-    }
-
-    #[inline]
-    pub fn dma_oam_addr() -> u16 {
-        DMA_OAM_ADDR.get()
-    }
-
-    #[inline]
-    #[must_use]
-    pub fn dmas_running() -> Option<(bool, bool)> {
-        let dmas = DMAS.get();
-        (!dmas.is_empty()).then_some((dmas.contains(Dma::DMC), dmas.contains(Dma::OAM)))
-    }
-
-    #[inline]
-    pub fn clear_dma(dma: Dma) {
-        DMAS.set(DMAS.get() & !dma);
-    }
-
-    #[inline]
-    pub fn clear_dma_halt() {
-        DMA_HALT.set(false);
-    }
-
-    #[inline]
-    pub fn dma_dummy_read() -> bool {
-        DMA_DUMMY_READ.get()
-    }
-
-    #[inline]
-    pub fn clear_dma_dummy_read() {
-        DMA_DUMMY_READ.set(false);
-    }
-
     /// Process an interrupted request.
     ///
     /// <https://wiki.nesdev.org/w/index.php/IRQ>
@@ -303,15 +317,15 @@ impl Cpu {
     ///  7    PC     R  fetch high byte of interrupt vector
     #[cold]
     #[inline(never)]
-    pub fn irq(&mut self) {
-        if Self::halt_for_dma() && self.region() == NesRegion::Pal {
+    pub fn irq(&mut self, intrs: &mut CpuInterrupts) {
+        if intrs.halt_for_dma() && self.region() == NesRegion::Pal {
             // Check for DMA on PAL
-            self.handle_dma(self.pc);
+            self.handle_dma(self.pc, intrs);
         }
 
-        self.read(self.pc); // Dummy read
-        self.read(self.pc); // Dummy read
-        self.push_word(self.pc);
+        self.read(self.pc, intrs); // Dummy read
+        self.read(self.pc, intrs); // Dummy read
+        self.push_word(self.pc, intrs);
 
         // Pushing status to the stack has to happen after checking NMI since it can hijack the BRK
         // IRQ when it occurs between cycles 4 and 5.
@@ -320,13 +334,13 @@ impl Cpu {
         // Set U and !B during push
         let status = ((self.status | Status::U) & !Status::B).bits();
         let nmi = self.irq_flags(IrqFlags::NMI);
-        self.push_byte(status);
+        self.push_byte(status, intrs);
         self.status.set(Status::I, true);
 
         if nmi {
             self.clear_irq_flags(IrqFlags::NMI);
-            self.pc = self.read_word(Self::NMI_VECTOR);
-            self.bus.ppu.clock_to(self.master_clock);
+            self.pc = self.read_word(Self::NMI_VECTOR, intrs);
+            self.bus.ppu.clock_to(self.master_clock, intrs);
             self.master_clock = self.master_clock.saturating_sub(self.bus.ppu.master_clock);
             self.bus.ppu.master_clock = 0;
             trace!(
@@ -334,7 +348,7 @@ impl Cpu {
                 self.bus.ppu.cycle, self.bus.ppu.scanline, self.cycle
             );
         } else {
-            self.pc = self.read_word(Self::IRQ_VECTOR);
+            self.pc = self.read_word(Self::IRQ_VECTOR, intrs);
             trace!(
                 "IRQ - PPU:{:3},{:3} CYC:{}",
                 self.bus.ppu.cycle, self.bus.ppu.scanline, self.cycle
@@ -344,33 +358,35 @@ impl Cpu {
 
     /// Handle CPU interrupt requests, if any are pending.
     #[inline(always)]
-    fn handle_interrupts(&mut self) {
-        let flags = &mut self.irq_flags;
-
+    fn handle_interrupts(&mut self, intrs: &mut CpuInterrupts) {
         // https://www.nesdev.org/wiki/CPU_interrupts
         //
         // The internal signal goes high during φ1 of the cycle that follows the one where
         // the edge is detected, and stays high until the NMI has been handled. NMI is handled only
         // when `prev_nmi` is true.
-        flags.set(IrqFlags::PREV_NMI, flags.contains(IrqFlags::NMI));
+        self.irq_flags
+            .set(IrqFlags::PREV_NMI, self.irq_flags.contains(IrqFlags::NMI));
 
         // This edge detector polls the status of the NMI line during φ2 of each CPU cycle (i.e.,
         // during the second half of each cycle, hence here in `end_cycle`) and raises an internal
         // signal if the input goes from being high during one cycle to being low during the
         // next.
-        let nmi_pending = Self::nmi_pending();
-        let prev_nmi_pending = flags.contains(IrqFlags::PREV_NMI_PENDING);
+        let nmi_pending = intrs.nmi_pending();
+        let prev_nmi_pending = self.irq_flags.contains(IrqFlags::PREV_NMI_PENDING);
         if !prev_nmi_pending && nmi_pending {
-            flags.insert(IrqFlags::NMI);
+            self.irq_flags.insert(IrqFlags::NMI);
         }
-        flags.set(IrqFlags::PREV_NMI_PENDING, nmi_pending);
+        self.irq_flags.set(IrqFlags::PREV_NMI_PENDING, nmi_pending);
 
         // The IRQ status at the end of the second-to-last cycle is what matters,
         // so keep the second-to-last status.
-        flags.set(IrqFlags::PREV_RUN_IRQ, flags.contains(IrqFlags::RUN_IRQ));
-        let irqs = Self::irqs();
+        self.irq_flags.set(
+            IrqFlags::PREV_RUN_IRQ,
+            self.irq_flags.contains(IrqFlags::RUN_IRQ),
+        );
+        let irqs = intrs.irqs;
         let run_irq = !irqs.is_empty() && !self.status.intersects(Status::I);
-        flags.set(IrqFlags::RUN_IRQ, run_irq);
+        self.irq_flags.set(IrqFlags::RUN_IRQ, run_irq);
 
         #[cfg(feature = "trace")]
         if !flags.contains(IrqFlags::PREV_NMI_PENDING) && flags.contains(IrqFlags::RUN_IRQ) {
@@ -380,44 +396,44 @@ impl Cpu {
 
     /// Start a CPU cycle.
     #[inline(always)]
-    fn start_cycle(&mut self, increment: u8) {
+    fn start_cycle(&mut self, increment: u8, intrs: &mut CpuInterrupts) {
         self.master_clock += u32::from(increment);
         self.cycle = self.cycle.wrapping_add(1);
-        self.bus.clock_to(self.master_clock - Self::PPU_OFFSET);
-        self.bus.clock();
+        self.bus.clock_to(self.master_clock - Self::PPU_OFFSET, intrs);
+        self.bus.clock(intrs);
     }
 
     /// End a CPU cycle.
     #[inline(always)]
-    fn end_cycle(&mut self, increment: u8) {
+    fn end_cycle(&mut self, increment: u8, intrs: &mut CpuInterrupts) {
         self.master_clock += u32::from(increment);
-        self.bus.clock_to(self.master_clock - Self::PPU_OFFSET);
+        self.bus.clock_to(self.master_clock - Self::PPU_OFFSET, intrs);
 
-        self.handle_interrupts();
+        self.handle_interrupts(intrs);
     }
 
     /// Start a direct-memory access (DMA) cycle.
     #[inline(always)]
-    fn start_dma_cycle(&mut self) {
+    fn start_dma_cycle(&mut self, intrs: &mut CpuInterrupts) {
         // OAM DMA cycles count as halt/dummy reads for DMC DMA when both run at the same time
-        if Self::halt_for_dma() {
-            Self::clear_dma_halt();
+        if intrs.halt_for_dma() {
+            intrs.clear_dma_halt();
         } else {
-            Self::clear_dma_dummy_read();
+            intrs.clear_dma_dummy_read();
         }
-        self.start_cycle(self.start_cycles - 1);
+        self.start_cycle(self.start_cycles - 1, intrs);
     }
 
     /// Handle a direct-memory access (DMA) request.
     #[cold]
     #[inline(never)]
-    fn handle_dma(&mut self, addr: u16) {
+    fn handle_dma(&mut self, addr: u16, intrs: &mut CpuInterrupts) {
         trace!("Starting DMA - CYC:{}", self.cycle);
 
-        self.start_cycle(self.start_cycles - 1);
-        self.bus.read(addr);
-        self.end_cycle(self.start_cycles + 1);
-        Self::clear_dma_halt();
+        self.start_cycle(self.start_cycles - 1, intrs);
+        self.bus.read(addr, intrs);
+        self.end_cycle(self.start_cycles + 1, intrs);
+        intrs.clear_dma_halt();
 
         let skip_dummy_reads = addr == 0x4016 || addr == 0x4017;
 
@@ -425,53 +441,53 @@ impl Cpu {
         let mut oam_dma_count = 0;
         let mut read_val = 0;
 
-        while let Some((dmc_dma, oam_dma)) = Self::dmas_running() {
+        while let Some((dmc_dma, oam_dma)) = intrs.dmas_running() {
             if self.cycle & 0x01 == 0x00 {
-                if dmc_dma && !Self::halt_for_dma() && !Self::dma_dummy_read() {
+                if dmc_dma && !intrs.halt_for_dma() && !intrs.dma_dummy_read() {
                     // DMC DMA ready to read a byte (halt and dummy read done before)
-                    self.start_dma_cycle();
+                    self.start_dma_cycle(intrs);
                     let dma_addr = self.bus.apu.dmc.dma_addr();
-                    read_val = self.bus.read(dma_addr);
+                    read_val = self.bus.read(dma_addr, intrs);
                     trace!(
                         "Loaded DMC DMA byte. ${dma_addr:04X}: {read_val} - CYC:{}",
                         self.cycle
                     );
-                    self.end_cycle(self.start_cycles + 1);
-                    self.bus.apu.dmc.load_buffer(read_val);
-                    Self::clear_dma(Dma::DMC);
+                    self.end_cycle(self.start_cycles + 1, intrs);
+                    self.bus.apu.dmc.load_buffer(read_val, intrs);
+                    intrs.clear_dma(Dma::DMC);
                 } else if oam_dma {
                     // DMC DMA not running or ready, run OAM DMA
-                    self.start_dma_cycle();
-                    read_val = self.bus.read(Self::dma_oam_addr() + oam_offset);
-                    self.end_cycle(self.start_cycles + 1);
+                    self.start_dma_cycle(intrs);
+                    read_val = self.bus.read(intrs.dma_oam_addr() + oam_offset, intrs);
+                    self.end_cycle(self.start_cycles + 1, intrs);
                     oam_offset += 1;
                     oam_dma_count += 1;
                 } else {
                     // DMC DMA running, but not ready yet (needs to halt, or dummy read) and OAM
                     // DMA isn't running
-                    debug_assert!(Self::halt_for_dma() || Self::dma_dummy_read());
-                    self.start_dma_cycle();
+                    debug_assert!(intrs.halt_for_dma() || intrs.dma_dummy_read());
+                    self.start_dma_cycle(intrs);
                     if !skip_dummy_reads {
-                        self.bus.read(addr); // throw away
+                        self.bus.read(addr, intrs); // throw away
                     }
-                    self.end_cycle(self.start_cycles + 1);
+                    self.end_cycle(self.start_cycles + 1, intrs);
                 }
             } else if oam_dma && oam_dma_count & 0x01 == 0x01 {
                 // OAM DMA write cycle, done on odd cycles after a read on even cycles
-                self.start_dma_cycle();
-                self.bus.write(0x2004, read_val);
-                self.end_cycle(self.start_cycles + 1);
+                self.start_dma_cycle(intrs);
+                self.bus.write(0x2004, read_val, intrs);
+                self.end_cycle(self.start_cycles + 1, intrs);
                 oam_dma_count += 1;
                 if oam_dma_count == 0x200 {
-                    Self::clear_dma(Dma::OAM);
+                    intrs.clear_dma(Dma::OAM);
                 }
             } else {
                 // Align to read cycle before starting OAM DMA (or align to perform DMC read)
-                self.start_dma_cycle();
+                self.start_dma_cycle(intrs);
                 if !skip_dummy_reads {
-                    self.bus.read(addr); // throw away
+                    self.bus.read(addr, intrs); // throw away
                 }
-                self.end_cycle(self.start_cycles + 1);
+                self.end_cycle(self.start_cycles + 1, intrs);
             }
         }
     }
@@ -542,17 +558,17 @@ impl Cpu {
 
     /// Push a byte to the stack.
     #[inline(always)]
-    fn push_byte(&mut self, val: u8) {
-        self.write(Self::SP_BASE | u16::from(self.sp), val);
+    fn push_byte(&mut self, val: u8, intrs: &mut CpuInterrupts) {
+        self.write(Self::SP_BASE | u16::from(self.sp), val, intrs);
         self.sp = self.sp.wrapping_sub(1);
     }
 
     /// Pull a byte from the stack.
     #[inline(always)]
     #[must_use]
-    fn pop_byte(&mut self) -> u8 {
+    fn pop_byte(&mut self, intrs: &mut CpuInterrupts) -> u8 {
         self.sp = self.sp.wrapping_add(1);
-        self.read(Self::SP_BASE | u16::from(self.sp))
+        self.read(Self::SP_BASE | u16::from(self.sp), intrs)
     }
 
     /// Peek byte at the top of the stack.
@@ -573,17 +589,17 @@ impl Cpu {
 
     /// Push a word (two bytes) to the stack
     #[inline(always)]
-    fn push_word(&mut self, val: u16) {
+    fn push_word(&mut self, val: u16, intrs: &mut CpuInterrupts) {
         let [lo, hi] = val.to_le_bytes();
-        self.push_byte(hi);
-        self.push_byte(lo);
+        self.push_byte(hi, intrs);
+        self.push_byte(lo, intrs);
     }
 
     /// Pull a word (two bytes) from the stack
     #[inline(always)]
-    fn pop_word(&mut self) -> u16 {
-        let lo = self.pop_byte();
-        let hi = self.pop_byte();
+    fn pop_word(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        let lo = self.pop_byte(intrs);
+        let hi = self.pop_byte(intrs);
         u16::from_le_bytes([lo, hi])
     }
 
@@ -592,8 +608,8 @@ impl Cpu {
     /// Fetch a byte and increments PC by 1.
     #[inline(always)]
     #[must_use]
-    fn fetch_byte(&mut self) -> u8 {
-        let val = self.read(self.pc);
+    fn fetch_byte(&mut self, intrs: &mut CpuInterrupts) -> u8 {
+        let val = self.read(self.pc, intrs);
         self.pc = self.pc.wrapping_add(1);
         val
     }
@@ -601,21 +617,21 @@ impl Cpu {
     /// Fetch opcode operand based on addressing mode.
     #[inline(always)]
     #[must_use]
-    fn fetch_operand(&mut self) -> u16 {
+    fn fetch_operand(&mut self, intrs: &mut CpuInterrupts) -> u16 {
         match self.addr_mode {
-            AddrMode::ACC | AddrMode::IMP => self.acc_imp(),
-            AddrMode::IMM | AddrMode::REL | AddrMode::ZP0 => self.imm_rel_zp(),
-            AddrMode::ZPX => self.zpx(),
-            AddrMode::ZPY => self.zpy(),
-            AddrMode::IND => self.ind(),
-            AddrMode::IDX => self.idx(),
-            AddrMode::IDY => self.idy(false),
-            AddrMode::IDYW => self.idy(true),
-            AddrMode::ABS => self.abs(),
-            AddrMode::ABX => self.abx(false),
-            AddrMode::ABXW => self.abx(true),
-            AddrMode::ABY => self.aby(false),
-            AddrMode::ABYW => self.aby(true),
+            AddrMode::ACC | AddrMode::IMP => self.acc_imp(intrs),
+            AddrMode::IMM | AddrMode::REL | AddrMode::ZP0 => self.imm_rel_zp(intrs),
+            AddrMode::ZPX => self.zpx(intrs),
+            AddrMode::ZPY => self.zpy(intrs),
+            AddrMode::IND => self.ind(intrs),
+            AddrMode::IDX => self.idx(intrs),
+            AddrMode::IDY => self.idy(false, intrs),
+            AddrMode::IDYW => self.idy(true, intrs),
+            AddrMode::ABS => self.abs(intrs),
+            AddrMode::ABX => self.abx(false, intrs),
+            AddrMode::ABXW => self.abx(true, intrs),
+            AddrMode::ABY => self.aby(false, intrs),
+            AddrMode::ABYW => self.aby(true, intrs),
             AddrMode::OTH => 0,
         }
     }
@@ -623,32 +639,32 @@ impl Cpu {
     /// Fetch a 16-bit word and increments PC by 2.
     #[inline(always)]
     #[must_use]
-    fn fetch_word(&mut self) -> u16 {
-        let lo = self.fetch_byte();
-        let hi = self.fetch_byte();
+    fn fetch_word(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        let lo = self.fetch_byte(intrs);
+        let hi = self.fetch_byte(intrs);
         u16::from_le_bytes([lo, hi])
     }
 
     /// Read operand value.
     #[inline(always)]
     #[must_use]
-    fn read_operand(&mut self) -> u8 {
+    fn read_operand(&mut self, intrs: &mut CpuInterrupts) -> u8 {
         if matches!(
             self.addr_mode,
             AddrMode::ACC | AddrMode::IMP | AddrMode::IMM | AddrMode::REL
         ) {
             self.operand as u8
         } else {
-            self.read(self.operand)
+            self.read(self.operand, intrs)
         }
     }
 
     /// Read a 16-bit word.
     #[inline(always)]
     #[must_use]
-    pub fn read_word(&mut self, addr: u16) -> u16 {
-        let lo = self.read(addr);
-        let hi = self.read(addr.wrapping_add(1));
+    pub fn read_word(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> u16 {
+        let lo = self.read(addr, intrs);
+        let hi = self.read(addr.wrapping_add(1), intrs);
         u16::from_le_bytes([lo, hi])
     }
 
@@ -859,35 +875,35 @@ impl Cpu {
 
 impl Clock for Cpu {
     /// Runs the CPU one instruction.
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut CpuInterrupts) {
         #[cfg(feature = "trace")]
         self.trace_instr();
 
-        let opcode = self.fetch_byte(); // Cycle 1
+        let opcode = self.fetch_byte(intrs); // Cycle 1
         let op = Cpu::OPS[usize::from(opcode)];
         self.addr_mode = op.addr_mode();
-        self.operand = self.fetch_operand();
-        op.run(self);
+        self.operand = self.fetch_operand(intrs);
+        op.run(self, intrs);
 
         if self
             .irq_flags
             .intersects(IrqFlags::PREV_RUN_IRQ | IrqFlags::PREV_NMI)
         {
-            self.irq();
+            self.irq(intrs);
         }
     }
 }
 
 impl Read for Cpu {
     #[inline(always)]
-    fn read(&mut self, addr: u16) -> u8 {
-        if Self::halt_for_dma() {
-            self.handle_dma(addr);
+    fn read(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> u8 {
+        if intrs.halt_for_dma() {
+            self.handle_dma(addr, intrs);
         }
 
-        self.start_cycle(self.start_cycles - 1);
-        let val = self.bus.read(addr);
-        self.end_cycle(self.end_cycles + 1);
+        self.start_cycle(self.start_cycles - 1, intrs);
+        let val = self.bus.read(addr, intrs);
+        self.end_cycle(self.end_cycles + 1, intrs);
         val
     }
 
@@ -898,10 +914,10 @@ impl Read for Cpu {
 
 impl Write for Cpu {
     #[inline(always)]
-    fn write(&mut self, addr: u16, val: u8) {
-        self.start_cycle(self.start_cycles + 1);
-        self.bus.write(addr, val);
-        self.end_cycle(self.end_cycles - 1);
+    fn write(&mut self, addr: u16, val: u8, intrs: &mut CpuInterrupts) {
+        self.start_cycle(self.start_cycles + 1, intrs);
+        self.bus.write(addr, val, intrs);
+        self.end_cycle(self.end_cycles - 1, intrs);
     }
 }
 
@@ -911,7 +927,7 @@ impl Regional for Cpu {
         self.bus.region
     }
 
-    fn set_region(&mut self, region: NesRegion) {
+    fn set_region(&mut self, region: NesRegion, intrs: &mut CpuInterrupts) {
         let (start_cycles, end_cycles) = match region {
             NesRegion::Auto | NesRegion::Ntsc => (6, 6), // NTSC_MASTER_CLOCK_DIVIDER / 2
             NesRegion::Pal => (8, 8),                    // PAL_MASTER_CLOCK_DIVIDER / 2
@@ -919,7 +935,7 @@ impl Regional for Cpu {
         };
         self.start_cycles = start_cycles;
         self.end_cycles = end_cycles;
-        self.bus.set_region(region);
+        self.bus.set_region(region, intrs);
     }
 }
 
@@ -929,7 +945,7 @@ impl Reset for Cpu {
     /// Updates the PC, SP, and Status values to defined constants.
     ///
     /// These operations take the CPU 7 cycles.
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
         trace!("{:?} RESET", kind);
 
         match kind {
@@ -948,20 +964,15 @@ impl Reset for Cpu {
             }
         }
 
-        self.bus.reset(kind);
+        self.bus.reset(kind, intrs);
         self.cycle = 0;
         self.master_clock = 0;
         self.irq_flags = IrqFlags::default();
         self.corrupted = false;
-        Self::clear_nmi();
-        Self::clear_irq(Irq::all());
-        Self::clear_dma_halt();
-        Self::clear_dma(Dma::all());
-        Self::clear_dma_dummy_read();
 
         // Read directly from bus so as to not clock other components during reset
-        let lo = self.bus.read(Self::RESET_VECTOR);
-        let hi = self.bus.read(Self::RESET_VECTOR + 1);
+        let lo = self.bus.read(Self::RESET_VECTOR, intrs);
+        let hi = self.bus.read(Self::RESET_VECTOR + 1, intrs);
         self.pc = u16::from_le_bytes([lo, hi]);
 
         // The CPU takes 7 cycles to reset/power on
@@ -969,8 +980,8 @@ impl Reset for Cpu {
         // * <https://www.nesdev.org/wiki/CPU_interrupts>
         // * <http://archive.6502.org/datasheets/synertek_programming_manual.pdf>
         for _ in 0..7 {
-            self.start_cycle(self.start_cycles - 1);
-            self.end_cycle(self.start_cycles + 1);
+            self.start_cycle(self.start_cycles - 1, intrs);
+            self.end_cycle(self.start_cycles + 1, intrs);
         }
     }
 }
@@ -986,7 +997,6 @@ impl fmt::Debug for Cpu {
             .field("y", &format_args!("${:02X}", self.y))
             .field("status", &self.status)
             .field("bus", &self.bus)
-            .field("irqs", &Self::irqs())
             .field("interrupt_flags", &self.irq_flags)
             .finish()
     }
@@ -1003,8 +1013,10 @@ mod tests {
         let mut cart = Cart::empty();
         cart.mapper = Nrom::load(&mut cart).unwrap();
         cpu.bus.load_cart(cart);
-        cpu.reset(ResetKind::Hard);
-        cpu.clock();
+
+        let mut intrs = CpuInterrupts::default();
+        cpu.reset(ResetKind::Hard, &mut intrs);
+        cpu.clock(&mut intrs);
 
         assert_eq!(cpu.cycle, 14, "cpu after power + one clock");
 
@@ -1017,9 +1029,9 @@ mod tests {
             if instr_ref.instr == HLT {
                 continue;
             }
-            cpu.reset(ResetKind::Hard);
-            cpu.bus.write(0x0000, instr_ref.opcode);
-            cpu.clock();
+            cpu.reset(ResetKind::Hard, &mut intrs);
+            cpu.bus.write(0x0000, instr_ref.opcode, &mut intrs);
+            cpu.clock(&mut intrs);
             let cpu_cyc = u32::from(7 + instr_ref.cycles + extra_cycle);
             assert_eq!(
                 cpu.cycle, cpu_cyc,

--- a/tetanes-core/src/cpu/instr.rs
+++ b/tetanes-core/src/cpu/instr.rs
@@ -1,7 +1,7 @@
 //! CPU Asddressing cmps and Operations
 
 use crate::{
-    cpu::{Cpu, IrqFlags, Status},
+    cpu::{Cpu, CpuInterrupts, IrqFlags, Status},
     mem::{Read, Write},
 };
 use serde::{Deserialize, Serialize};
@@ -49,14 +49,14 @@ pub enum AddrMode {
 #[derive(Debug, Copy, Clone)]
 #[must_use]
 pub struct Op {
-    f: fn(&mut Cpu),
+    f: fn(&mut Cpu, &mut CpuInterrupts),
     addr_mode: AddrMode,
 }
 
 impl Op {
     #[inline(always)]
-    pub fn run(&self, cpu: &mut Cpu) {
-        (self.f)(cpu)
+    pub fn run(&self, cpu: &mut Cpu, intrs: &mut CpuInterrupts) {
+        (self.f)(cpu, intrs)
     }
 
     #[inline(always)]
@@ -200,8 +200,8 @@ impl Cpu {
     ///    2    PC     R  read next instruction byte (and throw it away)
     /// ```
     #[inline(always)]
-    pub fn acc_imp(&mut self) -> u16 {
-        self.read(self.pc); // Cycle 2, dummy read
+    pub fn acc_imp(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        self.read(self.pc, intrs); // Cycle 2, dummy read
         0
     }
 
@@ -291,8 +291,8 @@ impl Cpu {
     ///    3  address  W  write register to effective address
     /// ```
     #[inline(always)]
-    pub fn imm_rel_zp(&mut self) -> u16 {
-        u16::from(self.fetch_byte()) // Cycle 2
+    pub fn imm_rel_zp(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        u16::from(self.fetch_byte(intrs)) // Cycle 2
     }
 
     /// Zero Page Addressing w/ X offset.
@@ -350,9 +350,9 @@ impl Cpu {
     ///       i.e. page boundary crossings are not handled.
     /// ```
     #[inline(always)]
-    pub fn zpx(&mut self) -> u16 {
-        let addr = u16::from(self.fetch_byte()); // Cycle 2
-        self.read(addr); // Cycle 3, dummy read
+    pub fn zpx(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        let addr = u16::from(self.fetch_byte(intrs)); // Cycle 2
+        self.read(addr, intrs); // Cycle 3, dummy read
         // High byte is always zero
         addr.wrapping_add(u16::from(self.x)) & 0x00FF
     }
@@ -393,9 +393,9 @@ impl Cpu {
     ///       i.e. page boundary crossings are not handled.
     /// ```
     #[inline(always)]
-    pub fn zpy(&mut self) -> u16 {
-        let addr = u16::from(self.fetch_byte()); // Cycle 2
-        self.read(addr); // Cycle 3, dummy read
+    pub fn zpy(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        let addr = u16::from(self.fetch_byte(intrs)); // Cycle 2
+        self.read(addr, intrs); // Cycle 3, dummy read
         // High byte is always zero
         addr.wrapping_add(u16::from(self.y)) & 0x00FF
     }
@@ -446,8 +446,8 @@ impl Cpu {
     ///  4  address  W  write register to effective address
     /// ```
     #[inline(always)]
-    pub fn abs(&mut self) -> u16 {
-        self.fetch_word() // Cycles 2-3
+    pub fn abs(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        self.fetch_word(intrs) // Cycles 2-3
     }
 
     /// Absolute Address w/ X offset.
@@ -522,12 +522,12 @@ impl Cpu {
     ///       address, it always reads from the address first.
     /// ```
     #[inline(always)]
-    pub fn abx(&mut self, dummy_read: bool) -> u16 {
-        let base_addr = self.fetch_word(); // Cycles 2-3
+    pub fn abx(&mut self, dummy_read: bool, intrs: &mut CpuInterrupts) -> u16 {
+        let base_addr = self.fetch_word(intrs); // Cycles 2-3
         let addr = base_addr.wrapping_add(u16::from(self.x));
         if Cpu::pages_differ(base_addr, addr) || dummy_read {
             // Cycle 4 dummy read with fixed high byte
-            self.read((base_addr & 0xFF00) | (addr & 0x00FF));
+            self.read((base_addr & 0xFF00) | (addr & 0x00FF), intrs);
         }
         addr
     }
@@ -604,12 +604,12 @@ impl Cpu {
     ///       address, it always reads from the address first.
     /// ```
     #[inline(always)]
-    pub fn aby(&mut self, dummy_read: bool) -> u16 {
-        let base_addr = self.fetch_word(); // Cycles 2 & 3
+    pub fn aby(&mut self, dummy_read: bool, intrs: &mut CpuInterrupts) -> u16 {
+        let base_addr = self.fetch_word(intrs); // Cycles 2 & 3
         let addr = base_addr.wrapping_add(u16::from(self.y));
         if Cpu::pages_differ(base_addr, addr) || dummy_read {
             // Cycle 4 dummy read with fixed high byte
-            self.read((base_addr & 0xFF00) | (addr & 0x00FF));
+            self.read((base_addr & 0xFF00) | (addr & 0x00FF), intrs);
         }
         addr
     }
@@ -638,8 +638,8 @@ impl Cpu {
     ///       than PCL, i.e. page boundary crossing is not handled.
     /// ```
     #[inline(always)]
-    pub fn ind(&mut self) -> u16 {
-        self.fetch_word()
+    pub fn ind(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        self.fetch_word(intrs)
     }
 
     /// Indirect X Addressing.
@@ -704,12 +704,12 @@ impl Cpu {
     ///       i.e. the zero page boundary crossing is not handled.
     /// ```
     #[inline(always)]
-    pub fn idx(&mut self) -> u16 {
-        let mut zero_addr = self.fetch_byte(); // Cycle 2
-        self.read(u16::from(zero_addr)); // Cycle 3 dummy read
+    pub fn idx(&mut self, intrs: &mut CpuInterrupts) -> u16 {
+        let mut zero_addr = self.fetch_byte(intrs); // Cycle 2
+        self.read(u16::from(zero_addr), intrs); // Cycle 3 dummy read
         zero_addr = zero_addr.wrapping_add(self.x);
-        let lo = self.read(u16::from(zero_addr)); // Cycle 4
-        let hi = self.read(u16::from(zero_addr.wrapping_add(1))); // Cycle 5
+        let lo = self.read(u16::from(zero_addr), intrs); // Cycle 4
+        let hi = self.read(u16::from(zero_addr.wrapping_add(1)), intrs); // Cycle 5
         u16::from_le_bytes([lo, hi])
     }
 
@@ -789,18 +789,18 @@ impl Cpu {
     ///       at this time, i.e. it may be smaller by $100.
     /// ```
     #[inline(always)]
-    pub fn idy(&mut self, dummy_read: bool) -> u16 {
-        let zero_addr = self.fetch_byte(); // Cycle 2
+    pub fn idy(&mut self, dummy_read: bool, intrs: &mut CpuInterrupts) -> u16 {
+        let zero_addr = self.fetch_byte(intrs); // Cycle 2
         let base_addr = {
-            let lo = self.read(u16::from(zero_addr)); // Cycle 4
-            let hi = self.read(u16::from(zero_addr.wrapping_add(1))); // Cycle 5
+            let lo = self.read(u16::from(zero_addr), intrs); // Cycle 4
+            let hi = self.read(u16::from(zero_addr.wrapping_add(1)), intrs); // Cycle 5
             u16::from_le_bytes([lo, hi])
         };
 
         let addr = base_addr.wrapping_add(u16::from(self.y));
         if Cpu::pages_differ(base_addr, addr) || dummy_read {
             // Cycle 5 dummy read with fixed high byte
-            self.read((base_addr & 0xFF00) | (addr & 0x00FF));
+            self.read((base_addr & 0xFF00) | (addr & 0x00FF), intrs);
         }
         addr
     }
@@ -812,67 +812,67 @@ impl Cpu {
 
     /// LDA: Load A with M
     #[inline(always)]
-    pub fn lda(&mut self) {
-        let val = self.read_operand();
+    pub fn lda(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(val);
     }
     /// LDX: Load X with M
     #[inline(always)]
-    pub fn ldx(&mut self) {
-        let val = self.read_operand();
+    pub fn ldx(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_x(val);
     }
     /// LDY: Load Y with M
     #[inline(always)]
-    pub fn ldy(&mut self) {
-        let val = self.read_operand();
+    pub fn ldy(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_y(val);
     }
 
     /// STA: Store A into M
     #[inline(always)]
-    pub fn sta(&mut self) {
-        self.write(self.operand, self.acc);
+    pub fn sta(&mut self, intrs: &mut CpuInterrupts) {
+        self.write(self.operand, self.acc, intrs);
     }
     /// STX: Store X into M
     #[inline(always)]
-    pub fn stx(&mut self) {
-        self.write(self.operand, self.x);
+    pub fn stx(&mut self, intrs: &mut CpuInterrupts) {
+        self.write(self.operand, self.x, intrs);
     }
     /// STY: Store Y into M
     #[inline(always)]
-    pub fn sty(&mut self) {
-        self.write(self.operand, self.y);
+    pub fn sty(&mut self, intrs: &mut CpuInterrupts) {
+        self.write(self.operand, self.y, intrs);
     }
 
     /// TAX: Transfer A to X
     #[inline(always)]
-    pub fn tax(&mut self) {
+    pub fn tax(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_x(self.acc);
     }
     /// TAY: Transfer A to Y
     #[inline(always)]
-    pub fn tay(&mut self) {
+    pub fn tay(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_y(self.acc);
     }
     /// TSX: Transfer Stack Pointer to X
     #[inline(always)]
-    pub fn tsx(&mut self) {
+    pub fn tsx(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_x(self.sp);
     }
     /// TXA: Transfer X to A
     #[inline(always)]
-    pub fn txa(&mut self) {
+    pub fn txa(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_acc(self.x);
     }
     /// TXS: Transfer X to Stack Pointer
     #[inline(always)]
-    pub const fn txs(&mut self) {
+    pub const fn txs(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_sp(self.x);
     }
     /// TYA: Transfer Y to A
     #[inline(always)]
-    pub fn tya(&mut self) {
+    pub fn tya(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_acc(self.y);
     }
 
@@ -880,14 +880,14 @@ impl Cpu {
 
     /// ADC: Add M to A with Carry
     #[inline(always)]
-    pub fn adc(&mut self) {
-        let val = self.read_operand();
+    pub fn adc(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.add(val);
     }
     /// SBC: Subtract M from A with Carry
     #[inline(always)]
-    pub fn sbc(&mut self) {
-        let val = self.read_operand();
+    pub fn sbc(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.add(val ^ 0xFF);
     }
     /// Utility function used by all add instructions
@@ -906,45 +906,45 @@ impl Cpu {
 
     /// INC: Increment M by One
     #[inline(always)]
-    pub fn inc(&mut self) {
+    pub fn inc(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.operand;
-        let val = self.read(addr);
-        self.write(addr, val); // Dummy write
+        let val = self.read(addr, intrs);
+        self.write(addr, val, intrs); // Dummy write
         let res = val.wrapping_add(1);
-        self.write(addr, res);
+        self.write(addr, res, intrs);
         self.set_zn_status(res);
     }
     /// DEC: Decrement M by One
     #[inline(always)]
-    pub fn dec(&mut self) {
+    pub fn dec(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.operand;
-        let val = self.read(addr);
-        self.write(addr, val); // Dummy write
+        let val = self.read(addr, intrs);
+        self.write(addr, val, intrs); // Dummy write
         let res = val.wrapping_sub(1);
-        self.write(addr, res);
+        self.write(addr, res, intrs);
         self.set_zn_status(res);
     }
 
     /// INX: Increment X by One
     #[inline(always)]
-    pub fn inx(&mut self) {
+    pub fn inx(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_x(self.x.wrapping_add(1));
     }
     /// INY: Increment Y by One
     #[inline(always)]
-    pub fn iny(&mut self) {
+    pub fn iny(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_y(self.y.wrapping_add(1));
     }
 
     /// DEX: Decrement X by One
     #[inline(always)]
-    pub fn dex(&mut self) {
+    pub fn dex(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_x(self.x.wrapping_sub(1));
     }
 
     /// DEY: Decrement Y by One
     #[inline(always)]
-    pub fn dey(&mut self) {
+    pub fn dey(&mut self, _intrs: &mut CpuInterrupts) {
         self.set_y(self.y.wrapping_sub(1));
     }
 
@@ -952,37 +952,37 @@ impl Cpu {
 
     /// AND: "And" M with A
     #[inline(always)]
-    pub fn and(&mut self) {
-        let val = self.read_operand();
+    pub fn and(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(self.acc & val);
     }
     /// EOR: "Exclusive-Or" M with A
     #[inline(always)]
-    pub fn eor(&mut self) {
-        let val = self.read_operand();
+    pub fn eor(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(self.acc ^ val);
     }
     /// ORA: "OR" M with A
     #[inline(always)]
-    pub fn ora(&mut self) {
-        let val = self.read_operand();
+    pub fn ora(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(self.acc | val);
     }
 
     /// ASL: Shift Left One Bit (A)
     #[inline(always)]
-    fn asla(&mut self) {
+    fn asla(&mut self, _intrs: &mut CpuInterrupts) {
         let val = self.asl(self.acc);
         self.set_acc(val);
     }
     /// ASL: Shift Left One Bit (M)
     #[inline(always)]
-    fn aslm(&mut self) {
+    fn aslm(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.operand;
-        let val = self.read(addr);
-        self.write(addr, val); // Dummy write
+        let val = self.read(addr, intrs);
+        self.write(addr, val, intrs); // Dummy write
         let res = self.asl(val);
-        self.write(addr, res);
+        self.write(addr, res, intrs);
     }
     /// Utility function used by all ASL instructions
     #[inline(always)]
@@ -995,18 +995,18 @@ impl Cpu {
 
     /// LSR: Shift Right One Bit (A)
     #[inline(always)]
-    pub fn lsra(&mut self) {
+    pub fn lsra(&mut self, _intrs: &mut CpuInterrupts) {
         let res = self.lsr(self.acc);
         self.set_acc(res);
     }
     /// LSR: Shift Right One Bit (M)
     #[inline(always)]
-    pub fn lsrm(&mut self) {
+    pub fn lsrm(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.operand;
-        let val = self.read(addr);
-        self.write(addr, val); // Dummy write
+        let val = self.read(addr, intrs);
+        self.write(addr, val, intrs); // Dummy write
         let res = self.lsr(val);
-        self.write(addr, res);
+        self.write(addr, res, intrs);
     }
     /// Utility function used by all LSR instructions
     #[inline(always)]
@@ -1019,18 +1019,18 @@ impl Cpu {
 
     /// ROL: Rotate One Bit Left (A)
     #[inline(always)]
-    pub fn rola(&mut self) {
+    pub fn rola(&mut self, _intrs: &mut CpuInterrupts) {
         let val = self.rol(self.acc);
         self.set_acc(val);
     }
     /// ROL: Rotate One Bit Left (M)
     #[inline(always)]
-    pub fn rolm(&mut self) {
+    pub fn rolm(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.operand;
-        let val = self.read(addr);
-        self.write(addr, val); // Dummy write
+        let val = self.read(addr, intrs);
+        self.write(addr, val, intrs); // Dummy write
         let val = self.rol(val);
-        self.write(addr, val);
+        self.write(addr, val, intrs);
     }
     /// Utility function used by all ROL instructions
     #[inline(always)]
@@ -1044,18 +1044,18 @@ impl Cpu {
 
     /// ROR: Rotate One Bit Right (A)
     #[inline(always)]
-    pub fn rora(&mut self) {
+    pub fn rora(&mut self, _intrs: &mut CpuInterrupts) {
         let val = self.ror(self.acc);
         self.set_acc(val);
     }
     /// ROR: Rotate One Bit Right (M)
     #[inline(always)]
-    pub fn rorm(&mut self) {
+    pub fn rorm(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.operand;
-        let val = self.read(addr);
-        self.write(addr, val); // Dummy write
+        let val = self.read(addr, intrs);
+        self.write(addr, val, intrs); // Dummy write
         let val = self.ror(val);
-        self.write(addr, val);
+        self.write(addr, val, intrs);
     }
     /// Utility function used by all ROR instructions
     #[inline(always)]
@@ -1069,8 +1069,8 @@ impl Cpu {
 
     /// BIT: Test Bits in M with A
     #[inline(always)]
-    pub fn bit(&mut self) {
-        let val = self.read_operand();
+    pub fn bit(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.status.set(Status::Z, (self.acc & val) == 0);
         self.status.set(Status::N, (val & 0x80) > 0);
         self.status.set(Status::V, (val & 0x40) > 0);
@@ -1080,47 +1080,47 @@ impl Cpu {
 
     /// BCC: Branch on Carry Clear
     #[inline(always)]
-    pub fn bcc(&mut self) {
-        self.branch(!self.status.contains(Status::C));
+    pub fn bcc(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(!self.status.contains(Status::C), intrs);
     }
     /// BCS: Branch on Carry Set
     #[inline(always)]
-    pub fn bcs(&mut self) {
-        self.branch(self.status.contains(Status::C));
+    pub fn bcs(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(self.status.contains(Status::C), intrs);
     }
     /// BEQ: Branch on Result Zero
     #[inline(always)]
-    pub fn beq(&mut self) {
-        self.branch(self.status.contains(Status::Z));
+    pub fn beq(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(self.status.contains(Status::Z), intrs);
     }
     /// BMI: Branch on Result Negative
     #[inline(always)]
-    pub fn bmi(&mut self) {
-        self.branch(self.status.contains(Status::N));
+    pub fn bmi(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(self.status.contains(Status::N), intrs);
     }
     /// BNE: Branch on Result Not Zero
     #[inline(always)]
-    pub fn bne(&mut self) {
-        self.branch(!self.status.contains(Status::Z));
+    pub fn bne(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(!self.status.contains(Status::Z), intrs);
     }
     /// BPL: Branch on Result Positive
     #[inline(always)]
-    pub fn bpl(&mut self) {
-        self.branch(!self.status.contains(Status::N));
+    pub fn bpl(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(!self.status.contains(Status::N), intrs);
     }
     /// BVC: Branch on Overflow Clear
     #[inline(always)]
-    pub fn bvc(&mut self) {
-        self.branch(!self.status.contains(Status::V));
+    pub fn bvc(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(!self.status.contains(Status::V), intrs);
     }
     /// BVS: Branch on Overflow Set
     #[inline(always)]
-    pub fn bvs(&mut self) {
-        self.branch(self.status.contains(Status::V));
+    pub fn bvs(&mut self, intrs: &mut CpuInterrupts) {
+        self.branch(self.status.contains(Status::V), intrs);
     }
     /// Utility function used by all branch instructions.
     #[inline(always)]
-    fn branch(&mut self, branch: bool) {
+    fn branch(&mut self, branch: bool, intrs: &mut CpuInterrupts) {
         if !branch {
             return;
         }
@@ -1131,11 +1131,11 @@ impl Cpu {
         if run_irq && !prev_run_irq {
             self.irq_flags.remove(IrqFlags::RUN_IRQ);
         }
-        self.read(self.pc); // Dummy read
+        self.read(self.pc, intrs); // Dummy read
 
         let offset = i16::from(self.operand as i8);
         if Self::page_crossed(self.pc, offset) {
-            self.read(self.pc); // Dummy read
+            self.read(self.pc, intrs); // Dummy read
         }
         self.pc = (self.pc as i16).wrapping_add(offset) as u16;
     }
@@ -1153,7 +1153,7 @@ impl Cpu {
     ///                   byte to PCH
     /// ```
     #[inline(always)]
-    pub const fn jmpa(&mut self) {
+    pub const fn jmpa(&mut self, _intrs: &mut CpuInterrupts) {
         self.pc = self.operand;
     }
     /// JMP: Jump to Location (indirect)
@@ -1170,14 +1170,14 @@ impl Cpu {
     ///       than PCL, i.e. page boundary crossing is not handled.
     /// ```
     #[inline(always)]
-    pub fn jmpi(&mut self) {
+    pub fn jmpi(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.operand;
         self.pc = if (addr & 0xFF) == 0xFF {
-            let lo = self.read(addr);
-            let hi = self.read(addr - 0xFF);
+            let lo = self.read(addr, intrs);
+            let hi = self.read(addr - 0xFF, intrs);
             u16::from_le_bytes([lo, hi])
         } else {
-            self.read_word(addr)
+            self.read_word(addr, intrs)
         };
     }
     /// JSR: Jump to Location Save Return addr
@@ -1194,11 +1194,11 @@ impl Cpu {
     ///                 byte to PCH
     /// ```
     #[inline(always)]
-    pub fn jsr(&mut self) {
-        let lo = self.fetch_byte();
-        self.read(self.pc); // Dummy read
-        self.push_word(self.pc);
-        let hi = self.fetch_byte();
+    pub fn jsr(&mut self, intrs: &mut CpuInterrupts) {
+        let lo = self.fetch_byte(intrs);
+        self.read(self.pc, intrs); // Dummy read
+        self.push_word(self.pc, intrs);
+        let hi = self.fetch_byte(intrs);
         let addr = u16::from_le_bytes([lo, hi]);
         self.pc = addr;
     }
@@ -1216,11 +1216,11 @@ impl Cpu {
     ///  6  $0100,S  R  pull PCH from stack
     /// ```
     #[inline(always)]
-    pub fn rti(&mut self) {
-        self.read(self.pc); // Dummy read
-        let status = Status::from_bits_truncate(self.pop_byte());
+    pub fn rti(&mut self, intrs: &mut CpuInterrupts) {
+        self.read(self.pc, intrs); // Dummy read
+        let status = Status::from_bits_truncate(self.pop_byte(intrs));
         self.set_status(status);
-        self.pc = self.pop_word();
+        self.pc = self.pop_word(intrs);
     }
 
     /// RTS: Return from Subroutine
@@ -1236,10 +1236,10 @@ impl Cpu {
     ///  6    PC     R  increment PC
     /// ```
     #[inline(always)]
-    pub fn rts(&mut self) {
-        self.read(self.pc); // Dummy read
-        let addr = self.pop_word();
-        self.read(self.pc); // Dummy read
+    pub fn rts(&mut self, intrs: &mut CpuInterrupts) {
+        self.read(self.pc, intrs); // Dummy read
+        let addr = self.pop_word(intrs);
+        self.read(self.pc, intrs); // Dummy read
         self.pc = addr.wrapping_add(1);
     }
 
@@ -1247,37 +1247,37 @@ impl Cpu {
 
     /// CLC: Clear Carry Flag
     #[inline(always)]
-    pub fn clc(&mut self) {
+    pub fn clc(&mut self, _intrs: &mut CpuInterrupts) {
         self.status.set(Status::C, false);
     }
     /// SEC: Set Carry Flag
     #[inline(always)]
-    pub fn sec(&mut self) {
+    pub fn sec(&mut self, _intrs: &mut CpuInterrupts) {
         self.status.set(Status::C, true);
     }
     /// CLD: Clear Decimal Mode
     #[inline(always)]
-    pub fn cld(&mut self) {
+    pub fn cld(&mut self, _intrs: &mut CpuInterrupts) {
         self.status.set(Status::D, false);
     }
     /// SED: Set Decimal Mode
     #[inline(always)]
-    pub fn sed(&mut self) {
+    pub fn sed(&mut self, _intrs: &mut CpuInterrupts) {
         self.status.set(Status::D, true);
     }
     /// CLI: Clear Interrupt Disable Bit
     #[inline(always)]
-    pub fn cli(&mut self) {
+    pub fn cli(&mut self, _intrs: &mut CpuInterrupts) {
         self.status.set(Status::I, false);
     }
     /// SEI: Set Interrupt Disable Status
     #[inline(always)]
-    pub fn sei(&mut self) {
+    pub fn sei(&mut self, _intrs: &mut CpuInterrupts) {
         self.status.set(Status::I, true);
     }
     /// CLV: Clear Overflow Flag
     #[inline(always)]
-    pub fn clv(&mut self) {
+    pub fn clv(&mut self, _intrs: &mut CpuInterrupts) {
         self.status.set(Status::V, false);
     }
 
@@ -1285,20 +1285,20 @@ impl Cpu {
 
     /// CMP: Compare M and A
     #[inline(always)]
-    pub fn cpa(&mut self) {
-        let val = self.read_operand();
+    pub fn cpa(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.cmp(self.acc, val);
     }
     /// CPX: Compare M and X
     #[inline(always)]
-    pub fn cpx(&mut self) {
-        let val = self.read_operand();
+    pub fn cpx(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.cmp(self.x, val);
     }
     /// CPY: Compare M and Y
     #[inline(always)]
-    pub fn cpy(&mut self) {
-        let val = self.read_operand();
+    pub fn cpy(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.cmp(self.y, val);
     }
     /// Utility function used by all compare instructions
@@ -1321,9 +1321,9 @@ impl Cpu {
     ///  3  $0100,S  W  push register on stack, decrement S
     /// ```
     #[inline(always)]
-    pub fn php(&mut self) {
+    pub fn php(&mut self, intrs: &mut CpuInterrupts) {
         // Set U and B when pushing during PHP and BRK
-        self.push_byte((self.status | Status::U | Status::B).bits());
+        self.push_byte((self.status | Status::U | Status::B).bits(), intrs);
     }
 
     /// PLP: Pull Processor Status from Stack
@@ -1337,9 +1337,9 @@ impl Cpu {
     ///  4  $0100,S  R  pull register from stack
     ///  ```
     #[inline(always)]
-    pub fn plp(&mut self) {
-        self.read(self.pc); // Dummy read
-        let status = Status::from_bits_truncate(self.pop_byte());
+    pub fn plp(&mut self, intrs: &mut CpuInterrupts) {
+        self.read(self.pc, intrs); // Dummy read
+        let status = Status::from_bits_truncate(self.pop_byte(intrs));
         self.set_status(status);
     }
 
@@ -1353,8 +1353,8 @@ impl Cpu {
     ///  3  $0100,S  W  push register on stack, decrement S
     /// ```
     #[inline(always)]
-    pub fn pha(&mut self) {
-        self.push_byte(self.acc); // Cycle 3
+    pub fn pha(&mut self, intrs: &mut CpuInterrupts) {
+        self.push_byte(self.acc, intrs); // Cycle 3
     }
 
     /// PLA: Pull A from Stack
@@ -1368,9 +1368,9 @@ impl Cpu {
     ///  4  $0100,S  R  pull register from stack
     /// ```
     #[inline(always)]
-    pub fn pla(&mut self) {
-        self.read(Self::SP_BASE | u16::from(self.sp)); // Dummy read
-        self.acc = self.pop_byte(); // Cycle 4
+    pub fn pla(&mut self, intrs: &mut CpuInterrupts) {
+        self.read(Self::SP_BASE | u16::from(self.sp), intrs); // Dummy read
+        self.acc = self.pop_byte(intrs); // Cycle 4
         self.set_zn_status(self.acc);
     }
 
@@ -1391,8 +1391,8 @@ impl Cpu {
     ///  7   $FFFF   R  fetch PCH
     /// ```
     #[inline(always)]
-    pub fn brk(&mut self) {
-        self.push_word(self.pc);
+    pub fn brk(&mut self, intrs: &mut CpuInterrupts) {
+        self.push_word(self.pc, intrs);
 
         // Pushing status to the stack has to happen after checking NMI since it can hijack the BRK
         // IRQ when it occurs between cycles 4 and 5.
@@ -1401,12 +1401,12 @@ impl Cpu {
         // Set U and B when pushing during PHP and BRK
         let status = (self.status | Status::U | Status::B).bits();
         let nmi = self.irq_flags.contains(IrqFlags::NMI);
-        self.push_byte(status); // Cycle 5
+        self.push_byte(status, intrs); // Cycle 5
         self.status.set(Status::I, true);
 
         if nmi {
             self.irq_flags.remove(IrqFlags::NMI);
-            self.pc = self.read_word(Self::NMI_VECTOR); // Cycles 6-7
+            self.pc = self.read_word(Self::NMI_VECTOR, intrs); // Cycles 6-7
             tracing::trace!(
                 "NMI - PPU:{:3},{:3} CYC:{}",
                 self.bus.ppu.cycle,
@@ -1414,7 +1414,7 @@ impl Cpu {
                 self.cycle
             );
         } else {
-            self.pc = self.read_word(Self::IRQ_VECTOR); // Cycles 6-7
+            self.pc = self.read_word(Self::IRQ_VECTOR, intrs); // Cycles 6-7
             tracing::trace!(
                 "IRQ - PPU:{:3},{:3} CYC:{}",
                 self.bus.ppu.cycle,
@@ -1436,15 +1436,15 @@ impl Cpu {
 
     /// NOP: No Operation
     #[inline(always)]
-    pub fn nop(&mut self) {
-        let _ = self.read_operand();
+    pub fn nop(&mut self, intrs: &mut CpuInterrupts) {
+        let _ = self.read_operand(intrs);
     }
 
     // Unofficial opcodes
 
     /// HLT: Captures all unimplemented opcodes and halts CPU
     #[inline(always)]
-    pub fn hlt(&mut self) {
+    pub fn hlt(&mut self, _intrs: &mut CpuInterrupts) {
         // Freezes CPU by rewiding and re-executing the bad opcode.
         self.pc = self.pc.wrapping_sub(1);
         // Prevent IRQ/NMI
@@ -1462,42 +1462,42 @@ impl Cpu {
 
     /// ISC/ISB: Shortcut for INC then SBC
     #[inline(always)]
-    pub fn isb(&mut self) {
-        let val = self.read_operand();
+    pub fn isb(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         let addr = self.operand;
         // INC
-        self.write(addr, val); // Dummy write
+        self.write(addr, val, intrs); // Dummy write
         let val = val.wrapping_add(1);
         // SBC
         self.add(val ^ 0xFF);
-        self.write(addr, val);
+        self.write(addr, val, intrs);
     }
 
     /// DCP: Shortcut for DEC then CMP
     #[inline(always)]
-    pub fn dcp(&mut self) {
-        let val = self.read_operand();
+    pub fn dcp(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         let addr = self.operand;
         // DEC
-        self.write(addr, val); // Dummy write
+        self.write(addr, val, intrs); // Dummy write
         let val = val.wrapping_sub(1);
         // CMP
         self.cmp(self.acc, val);
-        self.write(addr, val);
+        self.write(addr, val, intrs);
     }
 
     /// ATX: Shortcut for LDA & TAX
     #[inline(always)]
-    pub fn atx(&mut self) {
-        let val = self.read_operand();
+    pub fn atx(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(val); // LDA
         self.set_x(self.acc); // TAX
     }
 
     /// AXS: A & X into X
     #[inline(always)]
-    pub fn axs(&mut self) {
-        let val = self.read_operand();
+    pub fn axs(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         // CMP & DEX
         let res = (self.acc & self.x).wrapping_sub(val);
         self.status.set(Status::C, (self.acc & self.x) >= val);
@@ -1506,8 +1506,8 @@ impl Cpu {
 
     /// LAS: Shortcut for LDA then TSX, but ANDs memory stack pointer
     #[inline(always)]
-    pub fn las(&mut self) {
-        let val = self.read_operand();
+    pub fn las(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(val & self.sp);
         self.set_x(self.acc);
         self.set_sp(self.acc);
@@ -1515,8 +1515,8 @@ impl Cpu {
 
     /// LAX: Shortcut for LDA then TAX
     #[inline(always)]
-    pub fn lax(&mut self) {
-        let val = self.read_operand();
+    pub fn lax(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_x(val);
         self.set_acc(val);
     }
@@ -1525,44 +1525,50 @@ impl Cpu {
     /// AND Y register with the high byte of the target address of the argument + 1. Store the
     /// result in memory.
     #[inline(always)]
-    pub fn sya(&mut self) {
-        let base_addr = self.fetch_word();
-        self.sya_sxa_axa(base_addr, self.x, self.y);
+    pub fn sya(&mut self, intrs: &mut CpuInterrupts) {
+        let base_addr = self.fetch_word(intrs);
+        self.sya_sxa_axa(base_addr, self.x, self.y, intrs);
     }
 
     /// SXA/SHX/XAS: AND X with the high byte of the target address + 1
     #[inline(always)]
-    pub fn sxa(&mut self) {
-        let base_addr = self.fetch_word();
-        self.sya_sxa_axa(base_addr, self.y, self.x);
+    pub fn sxa(&mut self, intrs: &mut CpuInterrupts) {
+        let base_addr = self.fetch_word(intrs);
+        self.sya_sxa_axa(base_addr, self.y, self.x, intrs);
     }
 
     /// SHA/AXA: AND X with A then AND with 7, then store in memory
     #[inline(always)]
-    pub fn shaa(&mut self) {
-        let base_addr = self.fetch_word();
-        self.sya_sxa_axa(base_addr, self.y, self.x & self.acc);
+    pub fn shaa(&mut self, intrs: &mut CpuInterrupts) {
+        let base_addr = self.fetch_word(intrs);
+        self.sya_sxa_axa(base_addr, self.y, self.x & self.acc, intrs);
     }
 
     /// AHX: And X with A stores A&X&H into {adr}
     #[inline(always)]
-    pub fn shaz(&mut self) {
-        let zero_addr = self.fetch_byte();
+    pub fn shaz(&mut self, intrs: &mut CpuInterrupts) {
+        let zero_addr = self.fetch_byte(intrs);
         let base_addr = {
-            let lo = self.read(u16::from(zero_addr));
-            let hi = self.read(u16::from(zero_addr.wrapping_add(1)));
+            let lo = self.read(u16::from(zero_addr), intrs);
+            let hi = self.read(u16::from(zero_addr.wrapping_add(1)), intrs);
             u16::from_le_bytes([lo, hi])
         };
-        self.sya_sxa_axa(base_addr, self.y, self.x & self.acc);
+        self.sya_sxa_axa(base_addr, self.y, self.x & self.acc, intrs);
     }
 
-    fn sya_sxa_axa(&mut self, base_addr: u16, index_reg: u8, val_reg: u8) {
+    fn sya_sxa_axa(
+        &mut self,
+        base_addr: u16,
+        index_reg: u8,
+        val_reg: u8,
+        intrs: &mut CpuInterrupts,
+    ) {
         let addr = base_addr.wrapping_add(u16::from(index_reg));
         let page_crossed = Cpu::pages_differ(base_addr, addr);
 
         let start_cycles = self.cycle;
         // Dummy read with fixed high byte
-        self.read((base_addr & 0xFF00) | (addr & 0x00FF));
+        self.read((base_addr & 0xFF00) | (addr & 0x00FF), intrs);
 
         // Dummy read took more than 1 cycle, so it was interrupted by a DMA
         let had_dma = (self.cycle - start_cycles) > 1;
@@ -1578,39 +1584,39 @@ impl Cpu {
         } else {
             val_reg & ((base_addr >> 8) + 1) as u8
         };
-        self.write(u16::from_le_bytes([lo, hi]), val);
+        self.write(u16::from_le_bytes([lo, hi]), val, intrs);
     }
 
     /// SAX: AND A with X
     #[inline(always)]
-    pub fn sax(&mut self) {
-        self.write(self.operand, self.acc & self.x);
+    pub fn sax(&mut self, intrs: &mut CpuInterrupts) {
+        self.write(self.operand, self.acc & self.x, intrs);
     }
 
     /// XXA: Shortcutr for TXA with AND
     #[inline(always)]
-    pub fn xaa(&mut self) {
-        let val = self.read_operand();
+    pub fn xaa(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc((self.acc | 0xEE) & self.x & val);
     }
 
     /// RRA: Shortcut for ROR then ADC
     #[inline(always)]
-    pub fn rra(&mut self) {
-        let val = self.read_operand();
+    pub fn rra(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         let addr = self.operand;
         // ROR
-        self.write(addr, val); // Dummy write
+        self.write(addr, val, intrs); // Dummy write
         let shifted_val = self.ror(val);
         // ADC
         self.add(shifted_val);
-        self.write(addr, shifted_val);
+        self.write(addr, shifted_val, intrs);
     }
 
     /// TAS: Shortcut for STA then TXS, Same as SHA but sets SP = A & X
     #[inline(always)]
-    pub fn tas(&mut self) {
-        self.shaa();
+    pub fn tas(&mut self, intrs: &mut CpuInterrupts) {
+        self.shaa(intrs);
         // TXS
         self.set_sp(self.x & self.acc);
     }
@@ -1618,8 +1624,8 @@ impl Cpu {
     /// ARR: Shortcut for AND #imm then ROR, but sets flags differently
     /// C is bit 6 and V is bit 6 xor bit 5
     #[inline(always)]
-    pub fn arr(&mut self) {
-        let val = self.read_operand();
+    pub fn arr(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         let carry = self.status_bit(Status::C);
         self.set_acc(((self.acc & val) >> 1) | (carry << 7));
         self.status.set(Status::C, (self.acc & 0x40) > 0);
@@ -1631,21 +1637,21 @@ impl Cpu {
 
     /// SRA: Shortcut for LSR then EOR
     #[inline(always)]
-    pub fn sre(&mut self) {
-        let val = self.read_operand();
+    pub fn sre(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         let addr = self.operand;
         // LSR
-        self.write(addr, val); // Dummy write
+        self.write(addr, val, intrs); // Dummy write
         let shifted_val = self.lsr(val);
         // EOR
         self.set_acc(self.acc ^ shifted_val);
-        self.write(addr, shifted_val);
+        self.write(addr, shifted_val, intrs);
     }
 
     /// ALR/ASR: Shortcut for AND #imm then LSR
     #[inline(always)]
-    pub fn alr(&mut self) {
-        let val = self.read_operand();
+    pub fn alr(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(self.acc & val);
         self.status.set(Status::C, (self.acc & 0x01) > 0);
         self.set_acc(self.acc >> 1);
@@ -1653,35 +1659,35 @@ impl Cpu {
 
     /// RLA: Shortcut for ROL then AND
     #[inline(always)]
-    pub fn rla(&mut self) {
-        let val = self.read_operand();
+    pub fn rla(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         let addr = self.operand;
         // ROL
-        self.write(addr, val); // Dummy write
+        self.write(addr, val, intrs); // Dummy write
         let shifted_val = self.rol(val);
         // AND
         self.set_acc(self.acc & shifted_val);
-        self.write(addr, shifted_val);
+        self.write(addr, shifted_val, intrs);
     }
 
     /// ANC/AAC: AND #imm but puts bit 7 into carry as if ASL was executed
     #[inline(always)]
-    pub fn anc(&mut self) {
-        let val = self.read_operand();
+    pub fn anc(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         self.set_acc(self.acc & val);
         self.status.set(Status::C, self.status.contains(Status::N));
     }
 
     /// SLO: Shortcut for ASL then ORA
     #[inline(always)]
-    pub fn slo(&mut self) {
-        let val = self.read_operand();
+    pub fn slo(&mut self, intrs: &mut CpuInterrupts) {
+        let val = self.read_operand(intrs);
         let addr = self.operand;
         // ASL
-        self.write(addr, val); // Dummy write
+        self.write(addr, val, intrs); // Dummy write
         let shifted_val = self.asl(val);
         // ORA
         self.set_acc(self.acc | shifted_val);
-        self.write(addr, shifted_val);
+        self.write(addr, shifted_val, intrs);
     }
 }

--- a/tetanes-core/src/input.rs
+++ b/tetanes-core/src/input.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     common::{Clock, NesRegion, Reset, ResetKind},
-    cpu::Cpu,
+    cpu::{Cpu, CpuInterrupts},
     ppu::Ppu,
 };
 use bitflags::bitflags;
@@ -170,9 +170,9 @@ impl Input {
         self.zapper.connected = connected;
     }
 
-    pub fn set_four_player(&mut self, four_player: FourPlayer) {
+    pub fn set_four_player(&mut self, four_player: FourPlayer, intrs: &mut CpuInterrupts) {
         self.four_player = four_player;
-        self.reset(ResetKind::Hard);
+        self.reset(ResetKind::Hard, intrs);
     }
 
     pub fn clear(&mut self) {
@@ -261,8 +261,8 @@ impl InputRegisters for Input {
 }
 
 impl Clock for Input {
-    fn clock(&mut self) {
-        self.zapper.clock();
+    fn clock(&mut self, intrs: &mut CpuInterrupts) {
+        self.zapper.clock(intrs);
         if self.turbo_timer > 0 {
             self.turbo_timer -= 1;
         }
@@ -284,13 +284,13 @@ impl Clock for Input {
 }
 
 impl Reset for Input {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
         for pad in &mut self.joypads {
-            pad.reset(kind);
+            pad.reset(kind, intrs);
         }
         self.signatures[0] = Joypad::from_bytes(0b0000_1000);
         self.signatures[1] = Joypad::from_bytes(0b0000_0100);
-        self.zapper.reset(kind);
+        self.zapper.reset(kind, intrs);
     }
 }
 
@@ -456,7 +456,7 @@ impl Joypad {
 }
 
 impl Reset for Joypad {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut CpuInterrupts) {
         self.buttons = JoypadBtnState::empty();
         self.index = 0;
         self.strobe = false;
@@ -558,7 +558,7 @@ impl Zapper {
 }
 
 impl Clock for Zapper {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut CpuInterrupts) {
         if self.triggered > 0.0 {
             self.triggered -= 1.0;
         }
@@ -566,7 +566,7 @@ impl Clock for Zapper {
 }
 
 impl Reset for Zapper {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut CpuInterrupts) {
         self.triggered = 0.0;
     }
 }

--- a/tetanes-core/src/mapper.rs
+++ b/tetanes-core/src/mapper.rs
@@ -3,9 +3,7 @@
 //! <https://wiki.nesdev.org/w/index.php/Mapper>
 
 use crate::{
-    common::{Clock, Regional, Reset, Sram},
-    mem,
-    ppu::Mirroring,
+    common::{Clock, Regional, Reset, Sram}, cpu::CpuInterrupts, mem, ppu::Mirroring
 };
 use serde::{Deserialize, Serialize};
 
@@ -232,24 +230,24 @@ macro_rules! impl_map {
 }
 
 impl Map for Mapper {
-    fn map_read(&mut self, addr: u16) -> MappedRead {
-        impl_map!(self, map_read, addr)
+    fn map_read(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> MappedRead {
+        impl_map!(self, map_read, addr, intrs)
     }
 
     fn map_peek(&self, addr: u16) -> MappedRead {
         impl_map!(self, map_peek, addr)
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
-        impl_map!(self, map_write, addr, val)
+    fn map_write(&mut self, addr: u16, val: u8, intrs: &mut CpuInterrupts) -> MappedWrite {
+        impl_map!(self, map_write, addr, val, intrs)
     }
 
-    fn bus_read(&mut self, addr: u16, kind: BusKind) {
-        impl_map!(self, bus_read, addr, kind)
+    fn bus_read(&mut self, addr: u16, kind: BusKind, intrs: &mut CpuInterrupts) {
+        impl_map!(self, bus_read, addr, kind, intrs)
     }
 
-    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind) {
-        impl_map!(self, bus_write, addr, val, kind)
+    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind, intrs: &mut CpuInterrupts) {
+        impl_map!(self, bus_write, addr, val, kind, intrs)
     }
 
     fn mirroring(&self) -> Mirroring {
@@ -262,14 +260,14 @@ impl Map for Mapper {
 }
 
 impl Reset for Mapper {
-    fn reset(&mut self, kind: crate::prelude::ResetKind) {
-        impl_map!(self, reset, kind)
+    fn reset(&mut self, kind: crate::prelude::ResetKind, intrs: &mut CpuInterrupts) {
+        impl_map!(self, reset, kind, intrs)
     }
 }
 
 impl Clock for Mapper {
-    fn clock(&mut self) {
-        impl_map!(self, clock)
+    fn clock(&mut self, intrs: &mut CpuInterrupts) {
+        impl_map!(self, clock, intrs)
     }
 }
 
@@ -278,8 +276,8 @@ impl Regional for Mapper {
         impl_map!(self, region)
     }
 
-    fn set_region(&mut self, region: crate::prelude::NesRegion) {
-        impl_map!(self, set_region, region)
+    fn set_region(&mut self, region: crate::prelude::NesRegion, intrs: &mut CpuInterrupts) {
+        impl_map!(self, set_region, region, intrs)
     }
 }
 
@@ -364,7 +362,7 @@ pub enum BusKind {
 /// Trait implemented for all [`Mapper`]s.
 pub trait Map: Clock + Regional + Reset + Sram {
     /// Determine the [`MappedRead`] for the given address.
-    fn map_read(&mut self, addr: u16) -> MappedRead {
+    fn map_read(&mut self, addr: u16, _intrs: &mut CpuInterrupts) -> MappedRead {
         self.map_peek(addr)
     }
 
@@ -374,17 +372,24 @@ pub trait Map: Clock + Regional + Reset + Sram {
     }
 
     /// Determine the [`MappedWrite`] for the given address and value.
-    fn map_write(&mut self, _addr: u16, _val: u8) -> MappedWrite {
+    fn map_write(&mut self, _addr: u16, _val: u8, _intrs: &mut CpuInterrupts) -> MappedWrite {
         MappedWrite::default()
     }
 
     /// Simulates a read for the given bus at the given address for mappers that use bus reads for
     /// timing.
-    fn bus_read(&mut self, _addr: u16, _kind: BusKind) {}
+    fn bus_read(&mut self, _addr: u16, _kind: BusKind, _intrs: &mut CpuInterrupts) {}
 
     /// Simulates a write for the given bus at the given address for mappers that use bus writes for
     /// timing.
-    fn bus_write(&mut self, _addr: u16, _val: u8, _kind: BusKind) {}
+    fn bus_write(
+        &mut self,
+        _addr: u16,
+        _val: u8,
+        _kind: BusKind,
+        _intrs: &mut CpuInterrupts,
+    ) {
+    }
 
     /// Returns the current [`Mirroring`] mode.
     fn mirroring(&self) -> Mirroring {
@@ -396,7 +401,7 @@ pub trait Map: Clock + Regional + Reset + Sram {
 }
 
 impl Map for () {
-    fn map_read(&mut self, addr: u16) -> MappedRead {
+    fn map_read(&mut self, addr: u16, _intrs: &mut CpuInterrupts) -> MappedRead {
         self.map_peek(addr)
     }
 
@@ -404,13 +409,20 @@ impl Map for () {
         MappedRead::default()
     }
 
-    fn map_write(&mut self, _addr: u16, _val: u8) -> MappedWrite {
+    fn map_write(&mut self, _addr: u16, _val: u8, _intrs: &mut CpuInterrupts) -> MappedWrite {
         MappedWrite::default()
     }
 
-    fn bus_read(&mut self, _addr: u16, _kind: BusKind) {}
+    fn bus_read(&mut self, _addr: u16, _kind: BusKind, _intrs: &mut CpuInterrupts) {}
 
-    fn bus_write(&mut self, _addr: u16, _val: u8, _kind: BusKind) {}
+    fn bus_write(
+        &mut self,
+        _addr: u16,
+        _val: u8,
+        _kind: BusKind,
+        _intrs: &mut CpuInterrupts,
+    ) {
+    }
 
     fn mirroring(&self) -> Mirroring {
         Mirroring::default()

--- a/tetanes-core/src/mapper/bandai_fcg.rs
+++ b/tetanes-core/src/mapper/bandai_fcg.rs
@@ -5,7 +5,7 @@
 use crate::{
     cart::Cart,
     common::{Clock, Regional, Reset, Sram},
-    cpu::{Cpu, Irq},
+    cpu::{Irq},
     fs,
     mapper::{self, Map, MappedRead, MappedWrite, Mapper, Mirroring},
     mem::{Banks, Memory},
@@ -184,7 +184,7 @@ impl BandaiFCG {
         self.set_mirroring(mirroring);
     }
 
-    fn write_irq_ctrl(&mut self, val: u8) {
+    fn write_irq_ctrl(&mut self, val: u8, intrs: &mut crate::cpu::CpuInterrupts) {
         self.regs.irq_enabled = val & 0x01 == 0x01;
 
         // Wiki claims there is no reload value, however this seems to be the only way to make
@@ -195,7 +195,7 @@ impl BandaiFCG {
             self.regs.irq_counter = self.regs.irq_reload;
         }
 
-        Cpu::clear_irq(Irq::MAPPER);
+        intrs.clear_irq(Irq::MAPPER);
     }
 
     fn write_irq_latch(&mut self, addr: u16, val: u8) {
@@ -268,7 +268,7 @@ impl Map for BandaiFCG {
     // CPU $8000..=$BFFF 16K switchable PRG-ROM bank
     // CPU $C000..=$FFFF 16K PRG-ROM bank, fixed to the last bank
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
+    fn map_read(&mut self, addr: u16, _intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
         if matches!(addr, 0x6000..=0x7FFF) {
             if !matches!(self.sram_access, MemoryOp::Read | MemoryOp::ReadWrite) {
                 return MappedRead::Data(0x00);
@@ -300,7 +300,12 @@ impl Map for BandaiFCG {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => MappedWrite::ChrRam(self.chr_banks.translate(addr), val),
             0x6000..=0xFFFF => {
@@ -308,7 +313,7 @@ impl Map for BandaiFCG {
                     0x00..=0x07 => self.write_chr_bank(addr, val),
                     0x08 => self.write_prg_bank(val),
                     0x09 => self.write_mirroring(val),
-                    0x0A => self.write_irq_ctrl(val),
+                    0x0A => self.write_irq_ctrl(val, intrs),
                     0x0B..=0x0C => self.write_irq_latch(addr, val),
                     0x0D => {
                         if self.mapper_num == 153 {
@@ -336,16 +341,16 @@ impl Map for BandaiFCG {
 }
 
 impl Clock for BandaiFCG {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
         if let Some(barcode_reader) = &mut self.barcode_reader {
-            barcode_reader.clock();
+            barcode_reader.clock(intrs);
         }
         // Checking counter before decrementing seems to be the only way to get both Famicom Jump
         // II - Saikyou no 7 Nin (J) and Magical Taruruuto-kun 2 - Mahou Daibouken (J) to work
         // without glitches with the same code.
         if self.regs.irq_enabled {
             if self.regs.irq_counter == 0 {
-                Cpu::set_irq(Irq::MAPPER);
+                intrs.set_irq(Irq::MAPPER);
             }
             self.regs.irq_counter = self.regs.irq_counter.wrapping_sub(1);
         }
@@ -561,7 +566,7 @@ impl BarcodeReader {
 }
 
 impl Clock for BarcodeReader {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.master_clock += 1;
     }
 }

--- a/tetanes-core/src/mapper/m000_nrom.rs
+++ b/tetanes-core/src/mapper/m000_nrom.rs
@@ -57,7 +57,12 @@ impl Map for Nrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => MappedWrite::ChrRam(addr.into(), val),
             0x6000..=0x7FFF => MappedWrite::PrgRam((addr & 0x1FFF).into(), val),

--- a/tetanes-core/src/mapper/m001_sxrom.rs
+++ b/tetanes-core/src/mapper/m001_sxrom.rs
@@ -226,7 +226,12 @@ impl Map for Sxrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => MappedWrite::ChrRam(self.chr_banks.translate(addr), val),
             0x6000..=0x7FFF if self.prg_ram_enabled() => {
@@ -320,7 +325,7 @@ impl Map for Sxrom {
 }
 
 impl Reset for Sxrom {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.reset_buffer();
         self.regs.prg_mode = true;
         self.regs.prg_bank_select = true;
@@ -333,7 +338,7 @@ impl Reset for Sxrom {
 }
 
 impl Clock for Sxrom {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.regs.write_just_occurred > 0 {
             self.regs.write_just_occurred -= 1;
         }

--- a/tetanes-core/src/mapper/m002_uxrom.rs
+++ b/tetanes-core/src/mapper/m002_uxrom.rs
@@ -49,7 +49,12 @@ impl Map for Uxrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => MappedWrite::ChrRam(addr.into(), val),
             0x8000..=0xFFFF => {

--- a/tetanes-core/src/mapper/m003_cnrom.rs
+++ b/tetanes-core/src/mapper/m003_cnrom.rs
@@ -51,7 +51,12 @@ impl Map for Cnrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         if matches!(addr, 0x8000..=0xFFFF) {
             self.chr_banks.set(0, val.into());
         }

--- a/tetanes-core/src/mapper/m004_txrom.rs
+++ b/tetanes-core/src/mapper/m004_txrom.rs
@@ -6,7 +6,7 @@
 use crate::{
     cart::Cart,
     common::{Clock, Regional, Reset, ResetKind, Sram},
-    cpu::{Cpu, Irq},
+    cpu::Irq,
     mapper::{self, BusKind, Map, MappedRead, MappedWrite, Mapper},
     mem::Banks,
     ppu::Mirroring,
@@ -171,7 +171,7 @@ impl Txrom {
         };
     }
 
-    pub fn clock_irq(&mut self, addr: u16) {
+    pub fn clock_irq(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) {
         if addr < 0x2000 {
             let next_clock = (addr >> 12) & 1;
             let (last, next) = if self.revision == Revision::Acc {
@@ -190,7 +190,7 @@ impl Txrom {
                     && self.regs.irq_counter == 0
                     && self.regs.irq_enabled
                 {
-                    Cpu::set_irq(Irq::MAPPER);
+                    intrs.set_irq(Irq::MAPPER);
                 }
                 self.regs.irq_reload = false;
             }
@@ -214,8 +214,8 @@ impl Map for Txrom {
     // CPU $C000..=$DFFF (or $8000..=$9FFF) 8K PRG-ROM Bank 3 Fixed to second-to-last Bank
     // CPU $E000..=$FFFF 8K PRG-ROM Bank 4 Fixed to Last
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
-        self.clock_irq(addr);
+    fn map_read(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
+        self.clock_irq(addr, intrs);
         self.map_peek(addr)
     }
 
@@ -231,7 +231,12 @@ impl Map for Txrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => MappedWrite::ChrRam(self.chr_banks.translate(addr), val),
             0x2000..=0x3EFF if self.mirroring == Mirroring::FourScreen => {
@@ -289,7 +294,7 @@ impl Map for Txrom {
                     0xC000 => self.regs.irq_latch = val,
                     0xC001 => self.regs.irq_reload = true,
                     0xE000 => {
-                        Cpu::clear_irq(Irq::MAPPER);
+                        intrs.clear_irq(Irq::MAPPER);
                         self.regs.irq_enabled = false;
                     }
                     0xE001 => self.regs.irq_enabled = true,
@@ -301,17 +306,23 @@ impl Map for Txrom {
         }
     }
 
-    fn bus_read(&mut self, addr: u16, kind: BusKind) {
+    fn bus_read(&mut self, addr: u16, kind: BusKind, intrs: &mut crate::cpu::CpuInterrupts) {
         // Clock on PPU A12
         if kind == BusKind::Ppu {
-            self.clock_irq(addr);
+            self.clock_irq(addr, intrs);
         }
     }
 
-    fn bus_write(&mut self, addr: u16, _val: u8, kind: BusKind) {
+    fn bus_write(
+        &mut self,
+        addr: u16,
+        _val: u8,
+        kind: BusKind,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) {
         // Clock on PPU A12
         if kind == BusKind::Ppu {
-            self.clock_irq(addr);
+            self.clock_irq(addr, intrs);
         }
     }
 
@@ -325,7 +336,7 @@ impl Map for Txrom {
 }
 
 impl Reset for Txrom {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.regs = Regs::default();
         self.update_banks();
     }

--- a/tetanes-core/src/mapper/m005_exrom.rs
+++ b/tetanes-core/src/mapper/m005_exrom.rs
@@ -591,7 +591,7 @@ impl Map for Exrom {
     // CPU $C000..=$DFFF 8K switchable PRG ROM/RAM bank
     // CPU $E000..=$FFFF 8K switchable PRG ROM bank
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
+    fn map_read(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
         match addr {
             0x0000..=0x1FFF => {
                 self.inc_fetch_count();
@@ -632,7 +632,7 @@ impl Map for Exrom {
                             if status.scanline == self.regs.irq_scanline {
                                 irq_state.pending = true;
                                 if self.regs.irq_enabled {
-                                    Cpu::set_irq(Irq::MAPPER);
+                                    intrs.set_irq(Irq::MAPPER);
                                 }
                             }
                         } else {
@@ -650,17 +650,26 @@ impl Map for Exrom {
                 self.irq_state.in_frame = false; // NMI clears in_frame
                 self.irq_state.prev_addr = None;
                 self.irq_state.pending = false;
-                Cpu::clear_irq(Irq::MAPPER);
+                intrs.clear_irq(Irq::MAPPER);
             }
             _ => (),
         }
-        let val = self.map_peek(addr);
+        let val = match addr {
+            0x5010 => {
+                let irq = intrs.has_irq(Irq::DMC);
+                MappedRead::Data((u8::from(irq) << 7) | self.dmc_mode)
+            }
+            0x5204 => MappedRead::Data(
+                (u8::from(self.irq_state.pending) << 7) | (u8::from(self.irq_state.in_frame) << 6),
+            ),
+            _ => self.map_peek(addr),
+        };
         match addr {
             0x5204 => {
                 self.irq_state.pending = false;
-                Cpu::clear_irq(Irq::MAPPER);
+                intrs.clear_irq(Irq::MAPPER);
             }
-            0x5010 => Cpu::clear_irq(Irq::DMC),
+            0x5010 => intrs.clear_irq(Irq::DMC),
             _ => (),
         }
         val
@@ -722,8 +731,7 @@ impl Map for Exrom {
                 // [I... ...M] DMC
                 // I = IRQ (0 = No IRQ triggered. 1 = IRQ was triggered.) Reading $5010 acknowledges the IRQ and clears this flag.
                 // M = Mode select (0 = write mode. 1 = read mode.)
-                let irq = Cpu::has_irq(Irq::DMC);
-                MappedRead::Data((u8::from(irq) << 7) | self.dmc_mode)
+                MappedRead::Data(self.dmc_mode)
             }
             0x5100 => MappedRead::Data(self.regs.prg_mode as u8),
             0x5101 => MappedRead::Data(self.regs.chr_mode as u8),
@@ -758,11 +766,8 @@ impl Map for Exrom {
                 //   P = IRQ currently pending
                 //   I = "In Frame" signal
 
-                let irq_pending = Cpu::has_irq(Irq::MAPPER);
-                // Reading $5204 will clear the pending flag (acknowledging the IRQ).
-                // Clearing is done in the read() function
                 MappedRead::Data(
-                    (u8::from(irq_pending) << 7) | (u8::from(self.irq_state.in_frame) << 6),
+                    (u8::from(self.irq_state.pending) << 7) | (u8::from(self.irq_state.in_frame) << 6),
                 )
             }
             0x5205 => MappedRead::Data((self.regs.mult_result & 0xFF) as u8),
@@ -784,7 +789,12 @@ impl Map for Exrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x2000..=0x3EFF => match self.nametable_select(addr) {
                 Nametable::ScreenA => return MappedWrite::CIRam((addr & 0x03FF).into(), val),
@@ -954,9 +964,9 @@ impl Map for Exrom {
             0x5204 => {
                 self.regs.irq_enabled = val & 0x80 > 0; // [E... ....] IRQ Enable (0=disabled, 1=enabled)
                 if !self.regs.irq_enabled {
-                    Cpu::clear_irq(Irq::MAPPER);
+                    intrs.clear_irq(Irq::MAPPER);
                 } else if self.irq_state.pending {
-                    Cpu::set_irq(Irq::MAPPER);
+                    intrs.set_irq(Irq::MAPPER);
                 }
             }
             0x5205 => {
@@ -986,7 +996,13 @@ impl Map for Exrom {
         MappedWrite::Bus
     }
 
-    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind) {
+    fn bus_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        kind: BusKind,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) {
         if kind == BusKind::Cpu {
             match addr {
                 0x2000 => self.ppu_status.sprite8x16 = val & 0x20 > 0,
@@ -1012,14 +1028,14 @@ impl Map for Exrom {
 }
 
 impl Reset for Exrom {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.regs.prg_mode = PrgMode::Bank8k;
         self.regs.chr_mode = ChrMode::Bank1k;
     }
 }
 
 impl Clock for Exrom {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
         if self.ppu_status.reading {
             self.ppu_status.idle_count = 0;
         } else {
@@ -1033,13 +1049,13 @@ impl Clock for Exrom {
         }
         self.ppu_status.reading = false;
 
-        self.pulse1.clock();
-        self.pulse2.clock();
-        self.dmc.clock();
+        self.pulse1.clock(intrs);
+        self.pulse2.clock(intrs);
+        self.dmc.clock(intrs);
         self.pulse_timer -= 1.0;
         if self.pulse_timer <= 0.0 {
-            self.pulse1.clock_half_frame();
-            self.pulse2.clock_half_frame();
+            self.pulse1.clock_half_frame(intrs);
+            self.pulse2.clock_half_frame(intrs);
             self.pulse_timer = Cpu::region_clock_rate(self.region) / 240.0;
         }
 
@@ -1055,8 +1071,8 @@ impl Regional for Exrom {
         self.dmc.region()
     }
 
-    fn set_region(&mut self, region: NesRegion) {
-        self.dmc.set_region(region);
+    fn set_region(&mut self, region: NesRegion, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.dmc.set_region(region, intrs);
     }
 }
 

--- a/tetanes-core/src/mapper/m007_axrom.rs
+++ b/tetanes-core/src/mapper/m007_axrom.rs
@@ -48,7 +48,12 @@ impl Map for Axrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => MappedWrite::ChrRam(addr.into(), val),
             0x8000..=0xFFFF => {

--- a/tetanes-core/src/mapper/m009_pxrom.rs
+++ b/tetanes-core/src/mapper/m009_pxrom.rs
@@ -69,7 +69,7 @@ impl Map for Pxrom {
     // CPU $8000..=$9FFF 8K switchable PRG-ROM bank
     // CPU $A000..=$FFFF Three 8K PRG-ROM banks, fixed to the last three banks
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
+    fn map_read(&mut self, addr: u16, _intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
         let val = self.map_peek(addr);
         // Update latch after read
         match addr {
@@ -92,7 +92,12 @@ impl Map for Pxrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x6000..=0x7FFF => MappedWrite::PrgRam((addr & 0x1FFF).into(), val),
             0xA000..=0xAFFF => {
@@ -126,7 +131,7 @@ impl Map for Pxrom {
 }
 
 impl Reset for Pxrom {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.latch = [0x00; 2];
         self.latch_banks = [0x00; 4];
         self.update_banks();

--- a/tetanes-core/src/mapper/m010_fxrom.rs
+++ b/tetanes-core/src/mapper/m010_fxrom.rs
@@ -66,7 +66,7 @@ impl Map for Fxrom {
     // CPU $8000..=$BFFF 16K switchable PRG-ROM bank
     // CPU $C000..=$FFFF 16K PRG-ROM bank, fixed to the last bank
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
+    fn map_read(&mut self, addr: u16, _intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
         let val = self.map_peek(addr);
         // Update latch after read
         match addr {
@@ -89,7 +89,12 @@ impl Map for Fxrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x6000..=0x7FFF => MappedWrite::PrgRam((addr & 0x1FFF).into(), val),
             0xA000..=0xAFFF => {
@@ -123,7 +128,7 @@ impl Map for Fxrom {
 }
 
 impl Reset for Fxrom {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.latch = [0x00; 2];
         self.latch_banks = [0x00; 4];
         self.update_banks();

--- a/tetanes-core/src/mapper/m011_color_dreams.rs
+++ b/tetanes-core/src/mapper/m011_color_dreams.rs
@@ -48,7 +48,12 @@ impl Map for ColorDreams {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         if matches!(addr, 0x8000..=0xFFFF) {
             self.chr_banks
                 .set(0, ((val & Self::CHR_BANK_MASK) >> 4).into());

--- a/tetanes-core/src/mapper/m018_jalecoss88006.rs
+++ b/tetanes-core/src/mapper/m018_jalecoss88006.rs
@@ -5,7 +5,7 @@
 use crate::{
     cart::Cart,
     common::{Clock, Regional, Reset, ResetKind, Sram},
-    cpu::{Cpu, Irq},
+    cpu::Irq,
     mapper::{self, Map, MappedRead, MappedWrite, Mapper},
     mem::{BankAccess, Banks},
     ppu::Mirroring,
@@ -124,7 +124,12 @@ impl Map for JalecoSs88006 {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x6000..=0x7FFF => {
                 if self.prg_ram_banks.writable(addr) {
@@ -157,14 +162,14 @@ impl Map for JalecoSs88006 {
                 0xD002 | 0xD003 => self.update_chr_bank(7, val, PageBit::from(addr)),
                 0xE000..=0xE003 => self.regs.irq_reload[(addr & 0x03) as usize] = val,
                 0xF000 => {
-                    Cpu::clear_irq(Irq::MAPPER);
+                    intrs.clear_irq(Irq::MAPPER);
                     self.irq_counter = u16::from(self.regs.irq_reload[0])
                         | (u16::from(self.regs.irq_reload[1]) << 4)
                         | (u16::from(self.regs.irq_reload[2]) << 8)
                         | (u16::from(self.regs.irq_reload[3]) << 12);
                 }
                 0xF001 => {
-                    Cpu::clear_irq(Irq::MAPPER);
+                    intrs.clear_irq(Irq::MAPPER);
                     self.regs.irq_enabled = val & 0x01 == 0x01;
                     if val & 0x08 == 0x08 {
                         self.regs.irq_counter_size = 3;
@@ -202,7 +207,7 @@ impl Map for JalecoSs88006 {
 }
 
 impl Reset for JalecoSs88006 {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.regs = Regs::default();
         if kind == ResetKind::Hard {
             self.prg_rom_banks.set(3, self.prg_rom_banks.last());
@@ -211,12 +216,12 @@ impl Reset for JalecoSs88006 {
 }
 
 impl Clock for JalecoSs88006 {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
         if self.regs.irq_enabled {
             let irq_mask = Self::IRQ_MASKS[self.regs.irq_counter_size as usize];
             let counter = self.irq_counter & irq_mask;
             if counter == 0 {
-                Cpu::set_irq(Irq::MAPPER);
+                intrs.set_irq(Irq::MAPPER);
             }
             self.irq_counter =
                 (self.irq_counter & !irq_mask) | (counter.wrapping_sub(1) & irq_mask);

--- a/tetanes-core/src/mapper/m019_namco163.rs
+++ b/tetanes-core/src/mapper/m019_namco163.rs
@@ -5,7 +5,7 @@
 use crate::{
     cart::Cart,
     common::{Clock, Regional, Reset, ResetKind, Sample, Sram},
-    cpu::{Cpu, Irq},
+    cpu::Irq,
     fs,
     mapper::{self, Map, MappedRead, MappedWrite, Mapper},
     mem::{BankAccess, Banks, ConstArray, Memory},
@@ -178,7 +178,7 @@ impl Map for Namco163 {
     // $2800..=$2BFF bank 10 -> page N -> addr + page * $0400
     // $2C00..=$2FFF bank 11 -> page N -> addr + page * $0400
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
+    fn map_read(&mut self, addr: u16, _intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
         if matches!(addr, 0x4800..=0x4FFF) {
             MappedRead::Data(self.audio.read_register(addr))
         } else {
@@ -214,7 +214,12 @@ impl Map for Namco163 {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x3EFF => {
                 let bank = addr >> 10;
@@ -230,12 +235,12 @@ impl Map for Namco163 {
             0x5000..=0x57FF => {
                 self.maybe_set_board(Board::Namco163);
                 self.regs.irq_counter = (self.regs.irq_counter & 0xFF00) | u16::from(val);
-                Cpu::clear_irq(Irq::MAPPER);
+                intrs.clear_irq(Irq::MAPPER);
             }
             0x5800..=0x5FFF => {
                 self.maybe_set_board(Board::Namco163);
                 self.regs.irq_counter = (self.regs.irq_counter & 0xFF) | (u16::from(val) << 8);
-                Cpu::clear_irq(Irq::MAPPER);
+                intrs.clear_irq(Irq::MAPPER);
             }
             0x6000..=0x7FFF => {
                 self.prg_ram_written_to = true;
@@ -321,7 +326,7 @@ impl Map for Namco163 {
 }
 
 impl Reset for Namco163 {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         if kind == ResetKind::Hard {
             self.regs = Regs::default();
         }
@@ -337,15 +342,15 @@ impl Reset for Namco163 {
 }
 
 impl Clock for Namco163 {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
         if self.regs.irq_counter & 0x8000 > 0 && self.regs.irq_counter & 0x7FFF != 0x7FFF {
             self.regs.irq_counter = self.regs.irq_counter.wrapping_add(1);
             if self.regs.irq_counter & 0x7FFF == 0x7FFF {
-                Cpu::set_irq(Irq::MAPPER);
+                intrs.set_irq(Irq::MAPPER);
             }
         }
         if self.board == Board::Namco163 {
-            self.audio.clock();
+            self.audio.clock(intrs);
         }
     }
 }
@@ -556,7 +561,7 @@ impl Audio {
 }
 
 impl Clock for Audio {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if !self.disabled {
             self.update_counter += 1;
             if self.update_counter == 15 {

--- a/tetanes-core/src/mapper/m024_m026_vrc6.rs
+++ b/tetanes-core/src/mapper/m024_m026_vrc6.rs
@@ -260,7 +260,12 @@ impl Map for Vrc6 {
         }
     }
 
-    fn map_write(&mut self, mut addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        mut addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         if self.prg_ram_enabled() && matches!(addr, 0x6000..=0x7FFF) {
             return MappedWrite::PrgRam(self.prg_ram_banks.translate(addr), val);
         }
@@ -308,8 +313,8 @@ impl Map for Vrc6 {
                 self.update_chr_banks();
             }
             0xF000 => self.irq.write_reload(val),
-            0xF001 => self.irq.write_control(val),
-            0xF002 => self.irq.acknowledge(),
+            0xF001 => self.irq.write_control(val, intrs),
+            0xF002 => self.irq.acknowledge(intrs),
             _ => (),
         }
         MappedWrite::Bus
@@ -325,16 +330,16 @@ impl Map for Vrc6 {
 }
 
 impl Reset for Vrc6 {
-    fn reset(&mut self, kind: ResetKind) {
-        self.irq.reset(kind);
-        self.audio.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.irq.reset(kind, intrs);
+        self.audio.reset(kind, intrs);
     }
 }
 
 impl Clock for Vrc6 {
-    fn clock(&mut self) {
-        self.irq.clock();
-        self.audio.clock();
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.irq.clock(intrs);
+        self.audio.clock(intrs);
     }
 }
 
@@ -405,11 +410,11 @@ impl Audio {
 }
 
 impl Clock for Audio {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
         if !self.halt {
-            self.pulse1.clock();
-            self.pulse2.clock();
-            self.saw.clock();
+            self.pulse1.clock(intrs);
+            self.pulse2.clock(intrs);
+            self.saw.clock(intrs);
 
             self.out = self.pulse1.volume() + self.pulse2.volume() + self.saw.volume();
         }
@@ -417,7 +422,7 @@ impl Clock for Audio {
 }
 
 impl Reset for Audio {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.halt = false;
     }
 }
@@ -488,7 +493,7 @@ impl Pulse {
 }
 
 impl Clock for Pulse {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.enabled {
             self.timer -= 1;
             if self.timer == 0 {
@@ -562,7 +567,7 @@ impl Saw {
 }
 
 impl Clock for Saw {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.enabled {
             self.timer -= 1;
             if self.timer == 0 {

--- a/tetanes-core/src/mapper/m034_bnrom.rs
+++ b/tetanes-core/src/mapper/m034_bnrom.rs
@@ -47,7 +47,12 @@ impl Map for Bnrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => return MappedWrite::ChrRam(addr.into(), val),
             // Support up to 8MB PRG-ROM

--- a/tetanes-core/src/mapper/m034_nina001.rs
+++ b/tetanes-core/src/mapper/m034_nina001.rs
@@ -48,7 +48,12 @@ impl Map for Nina001 {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x0000..=0x1FFF => return MappedWrite::ChrRam(self.chr_banks.translate(addr), val),
             0x6000..=0x7FFF => {

--- a/tetanes-core/src/mapper/m066_gxrom.rs
+++ b/tetanes-core/src/mapper/m066_gxrom.rs
@@ -49,7 +49,12 @@ impl Map for Gxrom {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         if matches!(addr, 0x8000..=0xFFFF) {
             self.chr_banks.set(0, (val & Self::CHR_BANK_MASK).into());
             self.prg_rom_banks

--- a/tetanes-core/src/mapper/m069_sunsoft_fme7.rs
+++ b/tetanes-core/src/mapper/m069_sunsoft_fme7.rs
@@ -6,7 +6,7 @@ use crate::{
     apu::PULSE_TABLE,
     cart::Cart,
     common::{Clock, Regional, Reset, Sample, Sram},
-    cpu::{Cpu, Irq},
+    cpu::{Irq},
     mapper::{self, Map, MappedRead, MappedWrite, Mapper},
     mem::Banks,
     ppu::Mirroring,
@@ -90,7 +90,12 @@ impl Map for SunsoftFme7 {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         match addr {
             0x6000..=0x7FFF => {
                 if self.regs.prg_ram_enabled {
@@ -118,7 +123,7 @@ impl Map for SunsoftFme7 {
                 0xD => {
                     self.regs.irq_enabled = (val & 0x01) == 0x01;
                     self.regs.irq_counter_enabled = (val & 0x80) == 0x80;
-                    Cpu::clear_irq(Irq::MAPPER);
+                    intrs.clear_irq(Irq::MAPPER);
                 }
                 0xE => self.regs.irq_counter = (self.regs.irq_counter & 0xFF00) | u16::from(val),
                 0xF => {
@@ -144,14 +149,14 @@ impl Map for SunsoftFme7 {
 impl Reset for SunsoftFme7 {}
 
 impl Clock for SunsoftFme7 {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
         if self.regs.irq_counter_enabled {
             self.regs.irq_counter = self.regs.irq_counter.wrapping_sub(1);
             if self.regs.irq_counter == 0xFFFF && self.regs.irq_enabled {
-                Cpu::set_irq(Irq::MAPPER);
+                intrs.set_irq(Irq::MAPPER);
             }
         }
-        self.audio.clock();
+        self.audio.clock(intrs);
     }
 }
 
@@ -267,7 +272,7 @@ impl Audio {
 }
 
 impl Clock for Audio {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         if self.clock_timer == 0 {
             self.clock_timer = 1;
             for channel in 0..3 {

--- a/tetanes-core/src/mapper/m071_bf909x.rs
+++ b/tetanes-core/src/mapper/m071_bf909x.rs
@@ -70,7 +70,12 @@ impl Map for Bf909x {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         // Firehawk uses $9000 to change mirroring
         if addr == 0x9000 {
             self.revision = Revision::Bf9097;

--- a/tetanes-core/src/mapper/m076_dxrom.rs
+++ b/tetanes-core/src/mapper/m076_dxrom.rs
@@ -51,28 +51,39 @@ impl Map for Dxrom {
     // CPU $C000..=$DFFF (or $8000..=$9FFF) 8K PRG-ROM Bank 3 Fixed to second-to-last Bank
     // CPU $E000..=$FFFF 8K PRG-ROM Bank 4 Fixed to Last
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
-        self.inner.map_read(addr)
+    fn map_read(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
+        self.inner.map_read(addr, intrs)
     }
 
     fn map_peek(&self, addr: u16) -> MappedRead {
         self.inner.map_peek(addr)
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
-        let write = self.inner.map_write(addr, val);
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
+        let write = self.inner.map_write(addr, val, intrs);
         if matches!(addr, 0x8000..=0x8001) {
             self.update_chr_banks();
         }
         write
     }
 
-    fn bus_read(&mut self, addr: u16, kind: BusKind) {
-        self.inner.bus_read(addr, kind)
+    fn bus_read(&mut self, addr: u16, kind: BusKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.bus_read(addr, kind, intrs)
     }
 
-    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind) {
-        self.inner.bus_write(addr, val, kind)
+    fn bus_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        kind: BusKind,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) {
+        self.inner.bus_write(addr, val, kind, intrs)
     }
 
     fn mirroring(&self) -> Mirroring {
@@ -85,14 +96,14 @@ impl Map for Dxrom {
 }
 
 impl Reset for Dxrom {
-    fn reset(&mut self, kind: ResetKind) {
-        self.inner.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.reset(kind, intrs);
         self.update_chr_banks();
     }
 }
 impl Clock for Dxrom {
-    fn clock(&mut self) {
-        self.inner.clock();
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.clock(intrs);
     }
 }
 impl Regional for Dxrom {
@@ -100,8 +111,8 @@ impl Regional for Dxrom {
         self.inner.region()
     }
 
-    fn set_region(&mut self, region: NesRegion) {
-        self.inner.set_region(region)
+    fn set_region(&mut self, region: NesRegion, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.set_region(region, intrs)
     }
 }
 impl Sram for Dxrom {

--- a/tetanes-core/src/mapper/m079_nina003_006.rs
+++ b/tetanes-core/src/mapper/m079_nina003_006.rs
@@ -48,7 +48,12 @@ impl Map for Nina003006 {
         }
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        _intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         if matches!(addr, 0x0000..=0x1FFF) {
             // return MappedWrite::Chr(self.chr_banks.translate(addr), val);
         } else if (addr & 0xE100) == 0x4100 {

--- a/tetanes-core/src/mapper/m088_dxrom.rs
+++ b/tetanes-core/src/mapper/m088_dxrom.rs
@@ -59,28 +59,39 @@ impl Map for Dxrom {
     // CPU $C000..=$DFFF (or $8000..=$9FFF) 8K PRG-ROM Bank 3 Fixed to second-to-last Bank
     // CPU $E000..=$FFFF 8K PRG-ROM Bank 4 Fixed to Last
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
-        self.inner.map_read(addr)
+    fn map_read(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
+        self.inner.map_read(addr, intrs)
     }
 
     fn map_peek(&self, addr: u16) -> MappedRead {
         self.inner.map_peek(addr)
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
-        let write = self.inner.map_write(addr, val);
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
+        let write = self.inner.map_write(addr, val, intrs);
         if matches!(addr, 0x8000..=0x8001) {
             self.update_chr_banks();
         }
         write
     }
 
-    fn bus_read(&mut self, addr: u16, kind: BusKind) {
-        self.inner.bus_read(addr, kind)
+    fn bus_read(&mut self, addr: u16, kind: BusKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.bus_read(addr, kind, intrs)
     }
 
-    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind) {
-        self.inner.bus_write(addr, val, kind)
+    fn bus_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        kind: BusKind,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) {
+        self.inner.bus_write(addr, val, kind, intrs)
     }
 
     fn mirroring(&self) -> Mirroring {
@@ -93,14 +104,14 @@ impl Map for Dxrom {
 }
 
 impl Reset for Dxrom {
-    fn reset(&mut self, kind: ResetKind) {
-        self.inner.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.reset(kind, intrs);
         self.update_chr_banks();
     }
 }
 impl Clock for Dxrom {
-    fn clock(&mut self) {
-        self.inner.clock();
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.clock(intrs);
     }
 }
 impl Regional for Dxrom {
@@ -108,8 +119,8 @@ impl Regional for Dxrom {
         self.inner.region()
     }
 
-    fn set_region(&mut self, region: NesRegion) {
-        self.inner.set_region(region)
+    fn set_region(&mut self, region: NesRegion, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.set_region(region, intrs)
     }
 }
 impl Sram for Dxrom {

--- a/tetanes-core/src/mapper/m095_dxrom.rs
+++ b/tetanes-core/src/mapper/m095_dxrom.rs
@@ -39,16 +39,21 @@ impl Map for Dxrom {
     // CPU $C000..=$DFFF (or $8000..=$9FFF) 8K PRG-ROM Bank 3 Fixed to second-to-last Bank
     // CPU $E000..=$FFFF 8K PRG-ROM Bank 4 Fixed to Last
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
-        self.inner.map_read(addr)
+    fn map_read(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
+        self.inner.map_read(addr, intrs)
     }
 
     fn map_peek(&self, addr: u16) -> MappedRead {
         self.inner.map_peek(addr)
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
-        let write = self.inner.map_write(addr, val);
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
+        let write = self.inner.map_write(addr, val, intrs);
         if addr & 0x01 == 0x01 {
             let nametable1 = (self.inner.bank_register(0) >> 5) & 0x01;
             let nametable2 = (self.inner.bank_register(1) >> 5) & 0x01;
@@ -61,12 +66,18 @@ impl Map for Dxrom {
         write
     }
 
-    fn bus_read(&mut self, addr: u16, kind: BusKind) {
-        self.inner.bus_read(addr, kind)
+    fn bus_read(&mut self, addr: u16, kind: BusKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.bus_read(addr, kind, intrs)
     }
 
-    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind) {
-        self.inner.bus_write(addr, val, kind)
+    fn bus_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        kind: BusKind,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) {
+        self.inner.bus_write(addr, val, kind, intrs)
     }
 
     fn mirroring(&self) -> Mirroring {
@@ -79,13 +90,13 @@ impl Map for Dxrom {
 }
 
 impl Reset for Dxrom {
-    fn reset(&mut self, kind: ResetKind) {
-        self.inner.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.reset(kind, intrs);
     }
 }
 impl Clock for Dxrom {
-    fn clock(&mut self) {
-        self.inner.clock();
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.clock(intrs);
     }
 }
 impl Regional for Dxrom {
@@ -93,8 +104,8 @@ impl Regional for Dxrom {
         self.inner.region()
     }
 
-    fn set_region(&mut self, region: NesRegion) {
-        self.inner.set_region(region)
+    fn set_region(&mut self, region: NesRegion, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.set_region(region, intrs)
     }
 }
 impl Sram for Dxrom {

--- a/tetanes-core/src/mapper/m154_dxrom.rs
+++ b/tetanes-core/src/mapper/m154_dxrom.rs
@@ -39,29 +39,40 @@ impl Map for Dxrom {
     // CPU $C000..=$DFFF (or $8000..=$9FFF) 8K PRG-ROM Bank 3 Fixed to second-to-last Bank
     // CPU $E000..=$FFFF 8K PRG-ROM Bank 4 Fixed to Last
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
-        self.inner.map_read(addr)
+    fn map_read(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
+        self.inner.map_read(addr, intrs)
     }
 
     fn map_peek(&self, addr: u16) -> MappedRead {
         self.inner.map_peek(addr)
     }
 
-    fn map_write(&mut self, addr: u16, val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         self.set_mirroring(if val & 0x40 == 0x40 {
             Mirroring::SingleScreenB
         } else {
             Mirroring::SingleScreenA
         });
-        self.inner.map_write(addr, val)
+        self.inner.map_write(addr, val, intrs)
     }
 
-    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind) {
-        self.inner.bus_write(addr, val, kind)
+    fn bus_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        kind: BusKind,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) {
+        self.inner.bus_write(addr, val, kind, intrs)
     }
 
-    fn bus_read(&mut self, addr: u16, kind: BusKind) {
-        self.inner.bus_read(addr, kind)
+    fn bus_read(&mut self, addr: u16, kind: BusKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.bus_read(addr, kind, intrs)
     }
 
     fn mirroring(&self) -> Mirroring {
@@ -74,13 +85,13 @@ impl Map for Dxrom {
 }
 
 impl Reset for Dxrom {
-    fn reset(&mut self, kind: ResetKind) {
-        self.inner.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.reset(kind, intrs);
     }
 }
 impl Clock for Dxrom {
-    fn clock(&mut self) {
-        self.inner.clock();
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.clock(intrs);
     }
 }
 impl Regional for Dxrom {
@@ -88,8 +99,8 @@ impl Regional for Dxrom {
         self.inner.region()
     }
 
-    fn set_region(&mut self, region: NesRegion) {
-        self.inner.set_region(region)
+    fn set_region(&mut self, region: NesRegion, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.set_region(region, intrs)
     }
 }
 impl Sram for Dxrom {

--- a/tetanes-core/src/mapper/m206_dxrom.rs
+++ b/tetanes-core/src/mapper/m206_dxrom.rs
@@ -60,30 +60,41 @@ impl Map for Dxrom {
     // CPU $C000..=$DFFF (or $8000..=$9FFF) 8K PRG-ROM Bank 3 Fixed to second-to-last Bank
     // CPU $E000..=$FFFF 8K PRG-ROM Bank 4 Fixed to Last
 
-    fn map_read(&mut self, addr: u16) -> MappedRead {
-        self.inner.map_read(addr)
+    fn map_read(&mut self, addr: u16, intrs: &mut crate::cpu::CpuInterrupts) -> MappedRead {
+        self.inner.map_read(addr, intrs)
     }
 
     fn map_peek(&self, addr: u16) -> MappedRead {
         self.inner.map_peek(addr)
     }
 
-    fn map_write(&mut self, mut addr: u16, mut val: u8) -> MappedWrite {
+    fn map_write(
+        &mut self,
+        mut addr: u16,
+        mut val: u8,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) -> MappedWrite {
         // Apply register mask
         addr &= 0xE001;
         if addr == 0x8000 {
             // Disable CHR mode 1 and Prg mode 1
             val &= 0x3F;
         }
-        self.inner.map_write(addr, val)
+        self.inner.map_write(addr, val, intrs)
     }
 
-    fn bus_read(&mut self, addr: u16, kind: BusKind) {
-        self.inner.bus_read(addr, kind)
+    fn bus_read(&mut self, addr: u16, kind: BusKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.bus_read(addr, kind, intrs)
     }
 
-    fn bus_write(&mut self, addr: u16, val: u8, kind: BusKind) {
-        self.inner.bus_write(addr, val, kind)
+    fn bus_write(
+        &mut self,
+        addr: u16,
+        val: u8,
+        kind: BusKind,
+        intrs: &mut crate::cpu::CpuInterrupts,
+    ) {
+        self.inner.bus_write(addr, val, kind, intrs)
     }
 
     fn mirroring(&self) -> Mirroring {
@@ -96,13 +107,13 @@ impl Map for Dxrom {
 }
 
 impl Reset for Dxrom {
-    fn reset(&mut self, kind: ResetKind) {
-        self.inner.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.reset(kind, intrs);
     }
 }
 impl Clock for Dxrom {
-    fn clock(&mut self) {
-        self.inner.clock();
+    fn clock(&mut self, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.clock(intrs);
     }
 }
 impl Regional for Dxrom {
@@ -110,8 +121,8 @@ impl Regional for Dxrom {
         self.inner.region()
     }
 
-    fn set_region(&mut self, region: NesRegion) {
-        self.inner.set_region(region)
+    fn set_region(&mut self, region: NesRegion, intrs: &mut crate::cpu::CpuInterrupts) {
+        self.inner.set_region(region, intrs)
     }
 }
 impl Sram for Dxrom {

--- a/tetanes-core/src/mapper/vrc_irq.rs
+++ b/tetanes-core/src/mapper/vrc_irq.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     common::{Clock, Reset, ResetKind},
-    cpu::{Cpu, Irq},
+    cpu::{CpuInterrupts, Irq},
 };
 use serde::{Deserialize, Serialize};
 
@@ -24,7 +24,7 @@ impl VrcIrq {
         self.reload = val;
     }
 
-    pub fn write_control(&mut self, val: u8) {
+    pub fn write_control(&mut self, val: u8, intrs: &mut CpuInterrupts) {
         self.enabled_after_ack = val & 0x01 == 0x01;
         self.enabled = val & 0x02 == 0x02;
         self.cycle_mode = val & 0x04 == 0x04;
@@ -34,23 +34,23 @@ impl VrcIrq {
             self.prescalar_counter = 341;
         }
 
-        Cpu::clear_irq(Irq::MAPPER);
+        intrs.clear_irq(Irq::MAPPER);
     }
 
-    pub fn acknowledge(&mut self) {
+    pub fn acknowledge(&mut self, intrs: &mut CpuInterrupts) {
         self.enabled = self.enabled_after_ack;
-        Cpu::clear_irq(Irq::MAPPER);
+        intrs.clear_irq(Irq::MAPPER);
     }
 }
 
 impl Clock for VrcIrq {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut CpuInterrupts) {
         if self.enabled {
             self.prescalar_counter -= 3;
             if self.cycle_mode || self.prescalar_counter <= 0 {
                 if self.counter == 0xFF {
                     self.counter = self.reload;
-                    Cpu::set_irq(Irq::MAPPER);
+                    intrs.set_irq(Irq::MAPPER);
                 } else {
                     self.counter += 1;
                 }
@@ -61,12 +61,13 @@ impl Clock for VrcIrq {
 }
 
 impl Reset for VrcIrq {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, intrs: &mut CpuInterrupts) {
         self.reload = 0;
         self.counter = 0;
         self.prescalar_counter = 0;
         self.enabled = false;
         self.enabled_after_ack = false;
         self.cycle_mode = false;
+        intrs.clear_irq(Irq::MAPPER);
     }
 }

--- a/tetanes-core/src/mem.rs
+++ b/tetanes-core/src/mem.rs
@@ -14,6 +14,8 @@ use std::{
     str::FromStr,
 };
 
+use crate::cpu::CpuInterrupts;
+
 /// Represents ROM or RAM memory in bytes, with a custom Debug implementation that avoids
 /// printing the entire contents.
 #[derive(Default, Clone, Serialize, Deserialize)]
@@ -289,14 +291,14 @@ where
 /// A trait that represents memory read operations. Reads typically have side-effects.
 pub trait Read {
     /// Read from the given address.
-    fn read(&mut self, addr: u16) -> u8 {
+    fn read(&mut self, addr: u16, _intrs: &mut CpuInterrupts) -> u8 {
         self.peek(addr)
     }
 
     /// Read two bytes from the given address.
-    fn read_u16(&mut self, addr: u16) -> u16 {
-        let lo = self.read(addr);
-        let hi = self.read(addr.wrapping_add(1));
+    fn read_u16(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> u16 {
+        let lo = self.read(addr, intrs);
+        let hi = self.read(addr.wrapping_add(1), intrs);
         u16::from_le_bytes([lo, hi])
     }
 
@@ -314,13 +316,13 @@ pub trait Read {
 /// A trait that represents memory write operations.
 pub trait Write {
     /// Write value to the given address.
-    fn write(&mut self, addr: u16, val: u8);
+    fn write(&mut self, addr: u16, val: u8, intrs: &mut CpuInterrupts);
 
     /// Write  valuetwo bytes to the given address.
-    fn write_u16(&mut self, addr: u16, val: u16) {
+    fn write_u16(&mut self, addr: u16, val: u16, intrs: &mut CpuInterrupts) {
         let [lo, hi] = val.to_le_bytes();
-        self.write(addr, lo);
-        self.write(addr, hi);
+        self.write(addr, lo, intrs);
+        self.write(addr, hi, intrs);
     }
 }
 

--- a/tetanes-core/src/ppu.rs
+++ b/tetanes-core/src/ppu.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     common::{Clock, ClockTo, NesRegion, Regional, Reset, ResetKind},
-    cpu::Cpu,
+    cpu::{CpuInterrupts},
     debug::PpuDebugger,
     mapper::{BusKind, Map, Mapper},
     mem::{ConstArray, RamState, Read, Write},
@@ -42,11 +42,11 @@ pub enum Mirroring {
 /// Trait for PPU Registers.
 pub trait Registers {
     /// $2000 PPUCTRL
-    fn write_ctrl(&mut self, val: u8);
+    fn write_ctrl(&mut self, val: u8, intrs: &mut CpuInterrupts);
     /// Write $2001 PPUMASK
     fn write_mask(&mut self, val: u8);
     /// Read $2002 PPUSTATUS
-    fn read_status(&mut self) -> u8;
+    fn read_status(&mut self, intrs: &mut CpuInterrupts) -> u8;
     /// Peek $2002 PPUSTATUS
     fn peek_status(&self) -> u8;
     /// Write $2003 OAMADDR
@@ -60,13 +60,13 @@ pub trait Registers {
     /// Write $2005 PPUSCROLL
     fn write_scroll(&mut self, val: u8);
     /// Write $2006 PPUADDR
-    fn write_addr(&mut self, val: u8);
+    fn write_addr(&mut self, val: u8, intrs: &mut CpuInterrupts);
     /// Read $2007 PPUDATA
-    fn read_data(&mut self) -> u8;
+    fn read_data(&mut self, intrs: &mut CpuInterrupts) -> u8;
     /// Peek $2007 PPUDATA
     fn peek_data(&self) -> u8;
     /// Write $2007 PPUDATA
-    fn write_data(&mut self, val: u8);
+    fn write_data(&mut self, val: u8, intrs: &mut CpuInterrupts);
 }
 
 /// NES PPU.
@@ -298,7 +298,8 @@ impl Ppu {
             debugger: Default::default(),
         };
 
-        ppu.set_region(ppu.region);
+        let mut intrs = CpuInterrupts::default();
+        ppu.set_region(ppu.region, &mut intrs);
 
         ppu
     }
@@ -585,21 +586,21 @@ impl Ppu {
         }
     }
 
-    fn start_vblank(&mut self) {
+    fn start_vblank(&mut self, intrs: &mut CpuInterrupts) {
         trace!("Start VBL - PPU:{:3},{:3}", self.cycle, self.scanline);
         if !self.prevent_vbl {
             self.status.set_in_vblank(true);
             if self.ctrl.nmi_enabled {
-                Cpu::set_nmi();
+                intrs.set_nmi();
                 trace!("VBL NMI - PPU:{:3},{:3}", self.cycle, self.scanline,);
             }
         }
         self.prevent_vbl = false;
         let val = self.peek_status();
-        self.bus.mapper.bus_write(0x2002, val, BusKind::Ppu);
+        self.bus.mapper.bus_write(0x2002, val, BusKind::Ppu, intrs);
     }
 
-    fn stop_vblank(&mut self) {
+    fn stop_vblank(&mut self, intrs: &mut CpuInterrupts) {
         trace!(
             "Stop VBL, Sprite0 Hit, Overflow - PPU:{:3},{:3}",
             self.cycle, self.scanline
@@ -608,17 +609,17 @@ impl Ppu {
         self.status.set_spr_overflow(false);
         self.status.reset_in_vblank();
         self.reset_signal = false;
-        Cpu::clear_nmi();
+        intrs.clear_nmi();
         self.open_bus = 0; // Clear open bus every frame
         let val = self.peek_status();
-        self.bus.mapper.bus_write(0x2002, val, BusKind::Ppu);
+        self.bus.mapper.bus_write(0x2002, val, BusKind::Ppu, intrs);
     }
 
     /// Fetch BG nametable byte.
     ///
     /// See: <https://wiki.nesdev.org/w/index.php/PPU_scrolling#Tile_and_attribute_fetching>
     #[inline(always)]
-    fn fetch_bg_nt_byte(&mut self) {
+    fn fetch_bg_nt_byte(&mut self, intrs: &mut CpuInterrupts) {
         self.prev_palette = self.curr_palette;
         self.curr_palette = self.next_palette;
 
@@ -627,7 +628,7 @@ impl Ppu {
 
         let nametable_addr_mask = 0x0FFF; // Only need lower 12 bits
         let addr = Self::NT_START | (self.scroll.addr() & nametable_addr_mask);
-        let tile_index = u16::from(self.bus.read_ciram(addr));
+        let tile_index = u16::from(self.bus.read_ciram(addr, intrs));
         self.tile_addr = self.ctrl.bg_select | (tile_index << 4) | self.scroll.fine_y;
     }
 
@@ -635,10 +636,10 @@ impl Ppu {
     ///
     /// See: <https://wiki.nesdev.org/w/index.php/PPU_scrolling#Tile_and_attribute_fetching>
     #[inline(always)]
-    fn fetch_bg_attr_byte(&mut self) {
+    fn fetch_bg_attr_byte(&mut self, intrs: &mut CpuInterrupts) {
         let addr = self.scroll.attr_addr();
         let shift = self.scroll.attr_shift();
-        self.next_palette = ((self.bus.read_ciram(addr) >> shift) & 0x03) << 2;
+        self.next_palette = ((self.bus.read_ciram(addr, intrs) >> shift) & 0x03) << 2;
     }
 
     /// Fetch 4 tiles and write out shift registers every 8th cycle.
@@ -646,7 +647,7 @@ impl Ppu {
     ///
     /// See: <https://wiki.nesdev.org/w/index.php/PPU_scrolling#Tile_and_attribute_fetching>
     #[inline]
-    fn fetch_background(&mut self) {
+    fn fetch_background(&mut self, intrs: &mut CpuInterrupts) {
         match self.cycle & 0x07 {
             0 => {
                 if self.mask.prev_rendering_enabled {
@@ -658,10 +659,10 @@ impl Ppu {
                     }
                 }
             }
-            1 => self.fetch_bg_nt_byte(),
-            3 => self.fetch_bg_attr_byte(),
-            5 => self.tile_lo = self.bus.read_chr(self.tile_addr),
-            7 => self.tile_hi = self.bus.read_chr(self.tile_addr + 8),
+            1 => self.fetch_bg_nt_byte(intrs),
+            3 => self.fetch_bg_attr_byte(intrs),
+            5 => self.tile_lo = self.bus.read_chr(self.tile_addr, intrs),
+            7 => self.tile_hi = self.bus.read_chr(self.tile_addr + 8, intrs),
             _ => (),
         }
     }
@@ -794,7 +795,7 @@ impl Ppu {
         self.spr_count = spr_count;
     }
 
-    fn load_sprites(&mut self) {
+    fn load_sprites(&mut self, intrs: &mut CpuInterrupts) {
         // Local variables improve cache locality
         let cycle = self.cycle;
         let scanline = self.scanline;
@@ -840,8 +841,8 @@ impl Ppu {
                 let sprite = &mut self.sprites[idx];
                 sprite.x = x;
                 sprite.y = y;
-                sprite.tile_lo = self.bus.read_chr(tile_addr);
-                sprite.tile_hi = self.bus.read_chr(tile_addr + 8);
+                sprite.tile_lo = self.bus.read_chr(tile_addr, intrs);
+                sprite.tile_hi = self.bus.read_chr(tile_addr + 8, intrs);
                 sprite.palette = ((attr & 0x03) << 2) | 0x10;
                 sprite.bg_priority = (attr & 0x20) == 0x20;
                 sprite.flip_horizontal = (attr & 0x40) == 0x40;
@@ -852,25 +853,25 @@ impl Ppu {
             } else {
                 // Fetches for remaining sprites/hidden fetch tile $FF - used by MMC3 IRQ
                 // counter
-                let _ = self.bus.read_chr(tile_addr);
-                let _ = self.bus.read_chr(tile_addr + 8);
+                let _ = self.bus.read_chr(tile_addr, intrs);
+                let _ = self.bus.read_chr(tile_addr + 8, intrs);
             }
         }
     }
 
     // https://wiki.nesdev.org/w/index.php/PPU_OAM
-    fn fetch_sprites(&mut self) {
+    fn fetch_sprites(&mut self, intrs: &mut CpuInterrupts) {
         // OAMADDR set to $00 on prerender and visible scanlines
         self.write_oamaddr(0x00);
 
         match self.cycle & 0x07 {
             // Garbage NT sprite fetch (257, 265, 273, etc.) - Required for proper // MC-ACC IRQs
             // (MMC3 clone)
-            1 => self.fetch_bg_nt_byte(),   // Garbage NT fetch
-            3 => self.fetch_bg_attr_byte(), // Garbage attr fetch
+            1 => self.fetch_bg_nt_byte(intrs),   // Garbage NT fetch
+            3 => self.fetch_bg_attr_byte(intrs), // Garbage attr fetch
             // Cycle 260, 268, etc. This is an approximation (each tile is actually loaded in 8
             // steps (e.g from 257 to 264))
-            4 => self.load_sprites(),
+            4 => self.load_sprites(intrs),
             _ => (),
         }
     }
@@ -988,7 +989,7 @@ impl Ppu {
     }
 
     #[inline]
-    fn tick(&mut self) {
+    fn tick(&mut self, intrs: &mut CpuInterrupts) {
         // Local variables improve cache locality
         let cycle = self.cycle;
         let scanline = self.scanline;
@@ -1008,7 +1009,7 @@ impl Ppu {
                         if visible_scanline {
                             self.evaluate_sprites();
                         }
-                        self.fetch_background();
+                        self.fetch_background(intrs);
                         if prerender_scanline && cycle <= 8 && self.oamaddr >= 0x08 {
                             // If OAMADDR is not less than eight when rendering starts, the eight bytes
                             // starting at OAMADDR & 0xF8 are copied to the first eight bytes of OAM
@@ -1035,16 +1036,16 @@ impl Ppu {
                             // https://wiki.nesdev.org/w/index.php/PPU_rendering#Pre-render_scanline_.28-1.2C_261.29
                             self.scroll.copy_y();
                         }
-                        self.fetch_sprites();
+                        self.fetch_sprites(intrs);
                     }
                     // 321..=340
                     Self::BG_PREFETCH_START..=Self::CYCLE_END => {
                         // 336
                         if cycle <= Self::BG_PREFETCH_END {
-                            self.fetch_background();
+                            self.fetch_background(intrs);
                         } else if cycle >= Self::BG_DUMMY_START {
                             // 337..=340
-                            self.fetch_bg_nt_byte();
+                            self.fetch_bg_nt_byte(intrs);
                         }
                         self.oam_fetch = self.secondary_oamdata[0];
 
@@ -1073,13 +1074,13 @@ impl Ppu {
             }
         }
 
-        self.mask.clock();
+        self.mask.clock(intrs);
         if self.scroll.delayed_update()
             && (self.scanline > Self::VISIBLE_SCANLINE_END || !self.mask.rendering_enabled)
         {
             // MMC3 clocks using A12
             let addr = self.scroll.addr();
-            self.bus.mapper.bus_read(addr, BusKind::Ppu);
+            self.bus.mapper.bus_read(addr, BusKind::Ppu, intrs);
         }
 
         // Pixels should be put even if rendering is disabled, as this is what blanks out the
@@ -1123,7 +1124,7 @@ impl Registers for Ppu {
     //       |   5 | Sprite Size, 1 = 8x16, 0 = 8x8
     //       |   6 | Hit Switch, 1 = generate interrupts on Hit (incorrect ???)
     //       |   7 | VBlank Switch, 1 = generate interrupts on VBlank
-    fn write_ctrl(&mut self, val: u8) {
+    fn write_ctrl(&mut self, val: u8, intrs: &mut CpuInterrupts) {
         self.open_bus = val;
         if self.reset_signal && self.emulate_warmup {
             return;
@@ -1139,13 +1140,13 @@ impl Registers for Ppu {
         // By toggling NMI (bit 7) during VBlank without reading $2002, /NMI can be pulled low
         // multiple times, causing multiple NMIs to be generated.
         if !self.ctrl.nmi_enabled {
-            Cpu::clear_nmi();
+            intrs.clear_nmi();
         } else if self.status.in_vblank {
             trace!(
                 "$2000 NMI During VBL - PPU:{:3},{:3}",
                 self.cycle, self.scanline
             );
-            Cpu::set_nmi();
+            intrs.set_nmi();
         }
     }
 
@@ -1171,12 +1172,12 @@ impl Registers for Ppu {
     //       |     | This flag resets to 0 when VBlank starts, or CPU reads $2002
     //       |   7 | VBlank Flag, 1 = PPU is generating a Vertical Blanking Impulse
     //       |     | This flag resets to 0 when VBlank ends, or CPU reads $2002
-    fn read_status(&mut self) -> u8 {
+    fn read_status(&mut self, interrupts: &mut CpuInterrupts) -> u8 {
         let status = self.peek_status();
-        if Cpu::nmi_pending() {
+        if interrupts.nmi_pending() {
             trace!("$2002 NMI Ack - PPU:{:3},{:3}", self.cycle, self.scanline,);
         }
-        Cpu::clear_nmi();
+        interrupts.clear_nmi();
         self.status.reset_in_vblank();
         self.scroll.reset_latch();
 
@@ -1190,7 +1191,7 @@ impl Registers for Ppu {
             self.prevent_vbl = true;
         }
         self.open_bus |= status & 0xE0;
-        self.bus.mapper.bus_write(0x2002, status, BusKind::Ppu);
+        self.bus.mapper.bus_write(0x2002, status, BusKind::Ppu, interrupts);
         status
     }
 
@@ -1303,7 +1304,7 @@ impl Registers for Ppu {
 
     // $2006 | W   | PPUADDR
     #[inline(always)]
-    fn write_addr(&mut self, val: u8) {
+    fn write_addr(&mut self, val: u8, intrs: &mut CpuInterrupts) {
         self.open_bus = val;
         if self.reset_signal && self.emulate_warmup {
             return;
@@ -1312,17 +1313,17 @@ impl Registers for Ppu {
         // MMC3 clocks using A12
         self.bus
             .mapper
-            .bus_write(self.scroll.addr(), val, BusKind::Ppu);
+            .bus_write(self.scroll.addr(), val, BusKind::Ppu, intrs);
     }
 
     // $2007 | RW  | PPUDATA
-    fn read_data(&mut self) -> u8 {
+    fn read_data(&mut self, intrs: &mut CpuInterrupts) -> u8 {
         let addr = self.scroll.addr();
         self.increment_vram_addr();
 
         // Buffering quirk resulting in a dummy read for the CPU
         // for reading pre-palette data in $0000 - $3EFF
-        let val = self.bus.read(addr);
+        let val = self.bus.read(addr, intrs);
         let val = if addr < Self::PALETTE_START {
             let buffer = self.vram_buffer;
             self.vram_buffer = val;
@@ -1331,14 +1332,14 @@ impl Registers for Ppu {
             // Set internal buffer with mirrors of nametable when reading palettes
             // Since we're reading from > $3EFF subtract $1000 to fill
             // buffer with nametable mirror data
-            self.vram_buffer = self.bus.read(addr - 0x1000);
+            self.vram_buffer = self.bus.read(addr - 0x1000, intrs);
             // Hi 2 bits of palette should be open bus
             val | (self.open_bus & 0xC0)
         };
 
         self.open_bus = val;
         // MMC3 clocks using A12
-        self.bus.mapper.bus_read(self.scroll.addr(), BusKind::Ppu);
+        self.bus.mapper.bus_read(self.scroll.addr(), BusKind::Ppu, intrs);
 
         trace!(
             "PPU $2007 read: {val:02X} - PPU:{:3},{:3}",
@@ -1362,7 +1363,7 @@ impl Registers for Ppu {
     }
 
     // $2007 | RW  | PPUDATA
-    fn write_data(&mut self, val: u8) {
+    fn write_data(&mut self, val: u8, intrs: &mut CpuInterrupts) {
         self.open_bus = val;
         let addr = self.scroll.addr();
         trace!(
@@ -1370,25 +1371,25 @@ impl Registers for Ppu {
             self.cycle, self.scanline
         );
         self.increment_vram_addr();
-        self.bus.write(addr, val);
+        self.bus.write(addr, val, intrs);
 
         // MMC3 clocks using A12
         let addr = self.scroll.addr();
-        self.bus.mapper.bus_write(addr, val, BusKind::Ppu);
+        self.bus.mapper.bus_write(addr, val, BusKind::Ppu, intrs);
     }
 }
 
 impl Clock for Ppu {
-    fn clock(&mut self) {
+    fn clock(&mut self, intrs: &mut CpuInterrupts) {
         if self.cycle < Self::CYCLE_END {
             self.cycle += 1;
-            self.tick();
+            self.tick(intrs);
 
             if self.cycle == Self::VBLANK {
                 if self.scanline == self.vblank_scanline {
-                    self.start_vblank();
+                    self.start_vblank(intrs);
                 } else if self.scanline == self.prerender_scanline {
-                    self.stop_vblank();
+                    self.stop_vblank(intrs);
                 }
             }
         } else {
@@ -1413,9 +1414,9 @@ impl Clock for Ppu {
 }
 
 impl ClockTo for Ppu {
-    fn clock_to(&mut self, clock: u32) {
+    fn clock_to(&mut self, clock: u32, intrs: &mut CpuInterrupts) {
         while self.master_clock + self.clock_divider <= clock {
-            self.clock();
+            self.clock(intrs);
             self.master_clock += self.clock_divider;
         }
     }
@@ -1426,7 +1427,7 @@ impl Regional for Ppu {
         self.region
     }
 
-    fn set_region(&mut self, region: NesRegion) {
+    fn set_region(&mut self, region: NesRegion, intrs: &mut CpuInterrupts) {
         // https://www.nesdev.org/wiki/Cycle_reference_chart
         let (clock_divider, vblank_scanline, prerender_scanline) = match region {
             NesRegion::Auto | NesRegion::Ntsc => (
@@ -1451,17 +1452,17 @@ impl Regional for Ppu {
         self.prerender_scanline = prerender_scanline;
         // PAL refreshes OAM later due to extended vblank to avoid OAM decay
         self.pal_spr_eval_scanline = self.vblank_scanline + 24;
-        self.bus.set_region(region);
+        self.bus.set_region(region, intrs);
         self.mask.set_region(region);
     }
 }
 
 impl Reset for Ppu {
-    fn reset(&mut self, kind: ResetKind) {
-        self.ctrl.reset(kind);
-        self.mask.reset(kind);
-        self.status.reset(kind);
-        self.scroll.reset(kind);
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
+        self.ctrl.reset(kind, intrs);
+        self.mask.reset(kind, intrs);
+        self.status.reset(kind, intrs);
+        self.scroll.reset(kind, intrs);
         if kind == ResetKind::Soft {
             self.reset_signal = self.emulate_warmup;
         }
@@ -1475,7 +1476,7 @@ impl Reset for Ppu {
         self.scanline = 0;
         self.master_clock = 0;
         self.prevent_vbl = false;
-        self.frame.reset(kind);
+        self.frame.reset(kind, intrs);
         self.oam_fetch = 0x00;
         self.oam_eval_done = false;
         self.overflow_count = 0;
@@ -1486,7 +1487,7 @@ impl Reset for Ppu {
         self.sprites = [Sprite::new(); 8];
         self.spr_present = ConstArray::new();
         self.open_bus = 0x00;
-        self.bus.reset(kind);
+        self.bus.reset(kind, intrs);
     }
 }
 
@@ -1545,67 +1546,74 @@ mod tests {
     #[test]
     fn vram_writes() {
         let mut ppu = Ppu::default();
-        ppu.write_addr(0x23);
-        ppu.write_addr(0x05);
+        let mut intrs = CpuInterrupts::default();
+        ppu.write_addr(0x23, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.write_data(0x66); // write to $2305
 
-        assert_eq!(ppu.bus.read_ciram(0x2305), 0x66);
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.write_data(0x66, &mut intrs); // write to $2305
+
+        assert_eq!(ppu.bus.read_ciram(0x2305, &mut intrs), 0x66);
     }
 
     #[test]
     fn vram_reads() {
+        let mut intrs = CpuInterrupts::default();
         let mut ppu = Ppu::default();
-        ppu.write_ctrl(0x00);
-        ppu.bus.write(0x2305, 0x66);
+        ppu.write_ctrl(0x00, &mut intrs);
+        ppu.bus.write(0x2305, 0x66, &mut intrs);
 
-        ppu.write_addr(0x23);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x23, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
+
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
         assert_eq!(ppu.scroll.addr(), 0x2306);
-        assert_eq!(ppu.read_data(), 0x66);
+        assert_eq!(ppu.read_data(&mut intrs), 0x66);
         assert_eq!(ppu.scroll.addr(), 0x2307);
     }
 
     #[test]
     fn vram_read_pagecross() {
+        let mut intrs = CpuInterrupts::default();
         let mut ppu = Ppu::default();
-        ppu.write_ctrl(0x00);
-        ppu.bus.write(0x21FF, 0x66);
-        ppu.bus.write(0x2200, 0x77);
+        ppu.write_ctrl(0x00, &mut intrs);
+        ppu.bus.write(0x21FF, 0x66, &mut intrs);
+        ppu.bus.write(0x2200, 0x77, &mut intrs);
 
-        ppu.write_addr(0x21);
-        ppu.write_addr(0xFF);
+        ppu.write_addr(0x21, &mut intrs);
+        ppu.write_addr(0xFF, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
-        assert_eq!(ppu.read_data(), 0x66);
-        assert_eq!(ppu.read_data(), 0x77);
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_eq!(ppu.read_data(&mut intrs), 0x66);
+        assert_eq!(ppu.read_data(&mut intrs), 0x77);
     }
 
     #[test]
     fn vram_read_vertical_increment() {
         let mut ppu = Ppu::default();
-        ppu.write_ctrl(0b100);
-        ppu.bus.write(0x21FF, 0x66);
-        ppu.bus.write(0x21FF + 32, 0x77);
-        ppu.bus.write(0x21FF + 64, 0x88);
+        let mut intrs = CpuInterrupts::default();
 
-        ppu.write_addr(0x21);
-        ppu.write_addr(0xFF);
+        ppu.write_ctrl(0b100, &mut intrs);
+        ppu.bus.write(0x21FF, 0x66, &mut intrs);
+        ppu.bus.write(0x21FF + 32, 0x77, &mut intrs);
+        ppu.bus.write(0x21FF + 64, 0x88, &mut intrs);
+
+        ppu.write_addr(0x21, &mut intrs);
+        ppu.write_addr(0xFF, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
-        assert_eq!(ppu.read_data(), 0x66);
-        assert_eq!(ppu.read_data(), 0x77);
-        assert_eq!(ppu.read_data(), 0x88);
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_eq!(ppu.read_data(&mut intrs), 0x66);
+        assert_eq!(ppu.read_data(&mut intrs), 0x77);
+        assert_eq!(ppu.read_data(&mut intrs), 0x88);
     }
 
     // Horizontal: https://wiki.nesdev.org/w/index.php/Mirroring
@@ -1614,35 +1622,37 @@ mod tests {
     #[test]
     fn vram_horizontal_mirror() {
         let mut ppu = Ppu::default();
-        ppu.write_addr(0x24);
-        ppu.write_addr(0x05);
-        // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.write_data(0x66); // write to a at $2405
+        let mut intrs = CpuInterrupts::default();
 
-        ppu.write_addr(0x28);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x24, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.write_data(0x77); // write to B at $2805
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.write_data(0x66, &mut intrs); // write to a at $2405
 
-        ppu.write_addr(0x20);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x28, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
-        assert_eq!(ppu.read_data(), 0x66); // read A from $2005
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.write_data(0x77, &mut intrs); // write to B at $2805
 
-        ppu.write_addr(0x2C);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x20, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
-        assert_eq!(ppu.read_data(), 0x77); // read b from $2C05
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_eq!(ppu.read_data(&mut intrs), 0x66); // read A from $2005
+
+        ppu.write_addr(0x2C, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
+        // PPU writes to $2006 are delayed by 2 PPU clocks
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_eq!(ppu.read_data(&mut intrs), 0x77); // read b from $2C05
     }
 
     // Vertical: https://wiki.nesdev.org/w/index.php/Mirroring
@@ -1650,82 +1660,88 @@ mod tests {
     //   [0x2800 a ] [0x2C00 b ]
     #[test]
     fn vram_vertical_mirror() {
+        let mut intrs = CpuInterrupts::default();
+
         let mut ppu = Ppu::default();
         let mut cart = Cart::default();
         cart.mapper = Sxrom::load(&mut cart, Mmc1Revision::BC).unwrap();
         cart.mapper.set_mirroring(Mirroring::Vertical);
         ppu.load_mapper(cart.mapper);
 
-        ppu.write_addr(0x20);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x20, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.write_data(0x66); // write to A at $2005
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.write_data(0x66, &mut intrs); // write to A at $2005
 
-        ppu.write_addr(0x2C);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x2C, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.write_data(0x77); // write to b at $2C05
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.write_data(0x77, &mut intrs); // write to b at $2C05
 
-        ppu.write_addr(0x28);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x28, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
-        assert_eq!(ppu.read_data(), 0x66); // read a from $2805
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_eq!(ppu.read_data(&mut intrs), 0x66); // read a from $2805
 
-        ppu.write_addr(0x24);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x24, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
-        assert_eq!(ppu.read_data(), 0x77); // read B from $2405
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_eq!(ppu.read_data(&mut intrs), 0x77); // read B from $2405
     }
 
     #[test]
     fn read_status_resets_latch() {
+        let mut intrs = CpuInterrupts::default();
         let mut ppu = Ppu::default();
-        ppu.bus.write(0x2305, 0x66);
+        ppu.bus.write(0x2305, 0x66, &mut intrs);
+        let mut intrs = CpuInterrupts::default();
 
-        ppu.write_addr(0x21);
-        ppu.write_addr(0x23);
+        ppu.write_addr(0x21, &mut intrs);
+        ppu.write_addr(0x23, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.write_addr(0x05);
-        ppu.read_data(); // buffer read
-        assert_ne!(ppu.read_data(), 0x66);
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_ne!(ppu.read_data(&mut intrs), 0x66);
 
-        ppu.read_status();
+        ppu.read_status(&mut CpuInterrupts::default());
 
-        ppu.write_addr(0x23);
-        ppu.write_addr(0x05);
+        ppu.write_addr(0x23, &mut intrs);
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
-        assert_eq!(ppu.read_data(), 0x66);
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
+        assert_eq!(ppu.read_data(&mut intrs), 0x66);
     }
 
     #[test]
     fn vram_mirroring() {
-        let mut ppu = Ppu::default();
-        ppu.write_ctrl(0);
-        ppu.bus.write(0x2305, 0x66);
+        let mut intrs = CpuInterrupts::default();
 
-        ppu.write_addr(0x63); // 0x6305 mirrors to 0x2305
-        ppu.write_addr(0x05);
+        let mut ppu = Ppu::default();
+        ppu.write_ctrl(0, &mut intrs);
+        ppu.bus.write(0x2305, 0x66, &mut intrs);
+
+        ppu.write_addr(0x63, &mut intrs); // 0x6305 mirrors to 0x2305
+        ppu.write_addr(0x05, &mut intrs);
         // PPU writes to $2006 are delayed by 2 PPU clocks
-        ppu.clock();
-        ppu.clock();
-        ppu.read_data(); // buffer read
+        ppu.clock(&mut intrs);
+        ppu.clock(&mut intrs);
+        ppu.read_data(&mut intrs); // buffer read
         assert_eq!(ppu.scroll.addr(), 0x2306);
-        assert_eq!(ppu.read_data(), 0x66);
+        assert_eq!(ppu.read_data(&mut intrs), 0x66);
         assert_eq!(ppu.scroll.addr(), 0x2307);
     }
 
@@ -1734,7 +1750,8 @@ mod tests {
         let mut ppu = Ppu::default();
         ppu.status.set_in_vblank(true);
 
-        let status = ppu.read_status();
+        let mut intrs = CpuInterrupts::default();
+        let status = ppu.read_status(&mut intrs);
         assert_eq!(status >> 7, 1);
         assert_eq!(ppu.status.read() >> 7, 0);
     }
@@ -1761,7 +1778,8 @@ mod tests {
         ppu.sprites[0].bg_priority = false;
         ppu.status.set_spr_zero_hit(false);
 
-        ppu.tick();
+        let mut intrs = CpuInterrupts::default();
+        ppu.tick(&mut intrs);
 
         assert!(ppu.status.spr_zero_hit);
     }

--- a/tetanes-core/src/ppu/bus.rs
+++ b/tetanes-core/src/ppu/bus.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     common::{NesRegion, Regional, Reset, ResetKind},
+    cpu::CpuInterrupts,
     mapper::{BusKind, Map, MappedRead, MappedWrite, Mapper},
     mem::{ConstArray, Memory, RamState, Read, Write},
     ppu::{Mirroring, Ppu},
@@ -109,8 +110,8 @@ impl Bus {
         addr as usize
     }
 
-    pub fn read_ciram(&mut self, addr: u16) -> u8 {
-        match self.mapper.map_read(addr) {
+    pub fn read_ciram(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> u8 {
+        match self.mapper.map_read(addr, intrs) {
             MappedRead::Bus => self.ciram[Self::ciram_mirror(addr, self.mirroring())],
             MappedRead::CIRam(addr) => self.ciram[addr],
             MappedRead::ExRam(addr) => self.exram[addr],
@@ -145,8 +146,8 @@ impl Bus {
         }
     }
 
-    pub fn read_chr(&mut self, addr: u16) -> u8 {
-        let addr = if let MappedRead::Chr(addr) = self.mapper.map_read(addr) {
+    pub fn read_chr(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> u8 {
+        let addr = if let MappedRead::Chr(addr) = self.mapper.map_read(addr, intrs) {
             addr
         } else {
             addr.into()
@@ -171,10 +172,10 @@ impl Bus {
 }
 
 impl Read for Bus {
-    fn read(&mut self, addr: u16) -> u8 {
+    fn read(&mut self, addr: u16, intrs: &mut CpuInterrupts) -> u8 {
         let val = match addr {
-            0x2000..=0x3EFF => self.read_ciram(addr),
-            0x0000..=0x1FFF => self.read_chr(addr),
+            0x2000..=0x3EFF => self.read_ciram(addr, intrs),
+            0x0000..=0x1FFF => self.read_chr(addr, intrs),
             0x3F00..=0x3FFF => self.peek_palette(addr),
             _ => {
                 error!("unexpected PPU memory access at ${:04X}", addr);
@@ -199,9 +200,9 @@ impl Read for Bus {
 }
 
 impl Write for Bus {
-    fn write(&mut self, addr: u16, val: u8) {
+    fn write(&mut self, addr: u16, val: u8, intrs: &mut CpuInterrupts) {
         match addr {
-            0x0000..=0x3EFF => match self.mapper.map_write(addr, val) {
+            0x0000..=0x3EFF => match self.mapper.map_write(addr, val, intrs) {
                 MappedWrite::Bus => {
                     let addr = Self::ciram_mirror(addr, self.mirroring());
                     self.ciram[addr] = val;
@@ -231,7 +232,7 @@ impl Write for Bus {
             }
             _ => error!("unexpected PPU memory access at ${:04X}", addr),
         }
-        self.mapper.bus_write(addr, val, BusKind::Ppu);
+        self.mapper.bus_write(addr, val, BusKind::Ppu, intrs);
         self.open_bus = val;
     }
 }
@@ -241,18 +242,18 @@ impl Regional for Bus {
         self.mapper.region()
     }
 
-    fn set_region(&mut self, region: NesRegion) {
-        self.mapper.set_region(region);
+    fn set_region(&mut self, region: NesRegion, intrs: &mut CpuInterrupts) {
+        self.mapper.set_region(region, intrs);
     }
 }
 
 impl Reset for Bus {
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, intrs: &mut CpuInterrupts) {
         self.open_bus = 0x00;
         if self.chr_ram {
             self.ram_state.fill(&mut self.chr);
         }
-        self.mapper.reset(kind);
+        self.mapper.reset(kind, intrs);
     }
 }
 

--- a/tetanes-core/src/ppu/ctrl.rs
+++ b/tetanes-core/src/ppu/ctrl.rs
@@ -92,7 +92,7 @@ impl Ctrl {
 
 impl Reset for Ctrl {
     // https://www.nesdev.org/wiki/PPU_power_up_state
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.write(0);
     }
 }

--- a/tetanes-core/src/ppu/frame.rs
+++ b/tetanes-core/src/ppu/frame.rs
@@ -110,7 +110,7 @@ impl Frame {
 }
 
 impl Reset for Frame {
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.count = 0;
         self.buffer = Buffer::default();
     }

--- a/tetanes-core/src/ppu/mask.rs
+++ b/tetanes-core/src/ppu/mask.rs
@@ -105,13 +105,13 @@ impl Mask {
 
 impl Reset for Mask {
     // https://www.nesdev.org/wiki/PPU_power_up_state
-    fn reset(&mut self, _kind: ResetKind) {
+    fn reset(&mut self, _kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         self.write(0);
     }
 }
 
 impl Clock for Mask {
-    fn clock(&mut self) {
+    fn clock(&mut self, _intrs: &mut crate::cpu::CpuInterrupts) {
         // Rendering enabled flag is set with a 1 cycle delay (setting it at cycle N won't take
         // effect until cycle N+2)
         if self.pending_rendering_update {

--- a/tetanes-core/src/ppu/scroll.rs
+++ b/tetanes-core/src/ppu/scroll.rs
@@ -252,7 +252,7 @@ impl Scroll {
 
 impl Reset for Scroll {
     // https://www.nesdev.org/wiki/PPU_power_up_state
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         if kind == ResetKind::Hard {
             // v is not cleared on a a soft reset
             self.v = 0x0000;

--- a/tetanes-core/src/ppu/status.rs
+++ b/tetanes-core/src/ppu/status.rs
@@ -94,7 +94,7 @@ impl Status {
 
 impl Reset for Status {
     // https://www.nesdev.org/wiki/PPU_power_up_state
-    fn reset(&mut self, kind: ResetKind) {
+    fn reset(&mut self, kind: ResetKind, _intrs: &mut crate::cpu::CpuInterrupts) {
         if kind == ResetKind::Hard {
             self.set_in_vblank(false); // Technically random
             self.set_spr_zero_hit(false);


### PR DESCRIPTION
Platforms with poor thread local implementations can experience 4x slowdown because
thread locals get accessed a lot (mostly for reading, but still) in the emulation loop.

I experienced this on the powerpc64-unknown-freebsd target.
With thread locals: ~25 FPS
Without thread locals: 80 FPS

Having a separate interrupt struct is the correct and performant way of doing this in Rust,
because it has virtually no runtime cost.