### PR TITLE
n163: fixes for Sangokushi II / mapper 19

### DIFF
--- a/tetanes-core/src/mapper/m019_namco163.rs
+++ b/tetanes-core/src/mapper/m019_namco163.rs
@@ -126,15 +126,7 @@ impl Namco163 {
         let write_protect = self.regs.prg_ram_protect;
         match self.board {
             Board::Namco163 => {
-                let write_enable = write_protect & 0x40 == 0x40;
-                self.prg_ram_banks
-                    .set_access(0, access(write_enable && write_protect & 0x01 == 0x00));
-                self.prg_ram_banks
-                    .set_access(1, access(write_enable && write_protect & 0x02 == 0x00));
-                self.prg_ram_banks
-                    .set_access(2, access(write_enable && write_protect & 0x04 == 0x00));
-                self.prg_ram_banks
-                    .set_access(3, access(write_enable && write_protect & 0x08 == 0x00));
+                self.prg_ram_banks.set_access_range(0, 3, access(true));
             }
             Board::Namco175 => {
                 self.prg_ram_banks

--- a/tetanes-core/src/mapper/m019_namco163.rs
+++ b/tetanes-core/src/mapper/m019_namco163.rs
@@ -405,6 +405,8 @@ pub struct Audio {
     pub current_channel: i8,
     pub channel_out: [f32; Self::CHANNEL_COUNT],
     pub out: f32,
+    #[serde(skip, default)]
+    phase_ext: [u32; Self::CHANNEL_COUNT],
 }
 
 impl Default for Audio {
@@ -417,12 +419,9 @@ impl Audio {
     const CHANNEL_COUNT: usize = 8;
 
     const REG_FREQ_LOW: usize = 0x00;
-    const REG_PHASE_LOW: usize = 0x01;
     const REG_FREQ_MID: usize = 0x02;
-    const REG_PHASE_MID: usize = 0x03;
     const REG_FREQ_HIGH: usize = 0x04;
     const REG_WAVE_LEN: usize = 0x04;
-    const REG_PHASE_HIGH: usize = 0x05;
     const REG_WAVE_ADDR: usize = 0x06;
     const REG_VOLUME: usize = 0x07;
 
@@ -436,6 +435,7 @@ impl Audio {
             current_channel: 7,
             channel_out: [0.0; Self::CHANNEL_COUNT],
             out: 0.0,
+            phase_ext: [0; Self::CHANNEL_COUNT],
         }
     }
 
@@ -503,12 +503,8 @@ impl Audio {
 
     #[must_use]
     #[inline]
-    fn phase(&self) -> u32 {
-        let base_addr = self.base_addr();
-        let phase_high = u32::from(self.ram[base_addr + Self::REG_PHASE_HIGH]) << 16;
-        let phase_mid = u32::from(self.ram[base_addr + Self::REG_PHASE_MID]) << 8;
-        let phase_low = u32::from(self.ram[base_addr + Self::REG_PHASE_LOW]);
-        phase_high | phase_mid | phase_low
+    const fn phase(&self) -> u32 {
+        self.phase_ext[self.current_channel as usize]
     }
 
     #[must_use]
@@ -534,12 +530,8 @@ impl Audio {
     }
 
     #[inline]
-    #[allow(clippy::missing_const_for_fn)] // false positive on non-const deref coercion
-    fn set_phase(&mut self, phase: u32) {
-        let base_addr = self.base_addr();
-        self.ram[base_addr + Self::REG_PHASE_HIGH] = ((phase >> 16) & 0xFF) as u8;
-        self.ram[base_addr + Self::REG_PHASE_MID] = ((phase >> 8) & 0xFF) as u8;
-        self.ram[base_addr + Self::REG_PHASE_LOW] = (phase & 0xFF) as u8;
+    const fn set_phase(&mut self, phase: u32) {
+        self.phase_ext[self.current_channel as usize] = phase;
     }
 
     #[must_use]

--- a/tetanes-core/src/mapper/m019_namco163.rs
+++ b/tetanes-core/src/mapper/m019_namco163.rs
@@ -380,11 +380,16 @@ impl Regional for Namco163 {}
 
 impl Sram for Namco163 {
     fn save(&self, path: impl AsRef<std::path::Path>) -> fs::Result<()> {
-        fs::save(path.as_ref().with_extension("ciram"), &self.audio.ram)
+        fs::save(path.as_ref(), &(&self.prg_ram, &self.audio.ram))
     }
 
     fn load(&mut self, path: impl AsRef<std::path::Path>) -> fs::Result<()> {
-        fs::load(path.as_ref().with_extension("ciram")).map(|data| self.audio.ram = data)
+        fs::load::<(Memory<Box<[u8]>>, ConstArray<u8, 0x80>)>(path.as_ref()).map(
+            |(prg_ram, audio_ram)| {
+                self.prg_ram = prg_ram;
+                self.audio.ram = audio_ram;
+            },
+        )
     }
 }
 

--- a/tetanes-core/src/mapper/m019_namco163.rs
+++ b/tetanes-core/src/mapper/m019_namco163.rs
@@ -78,7 +78,7 @@ impl Namco163 {
             regs: Regs::default(),
             board: match cart.mapper_num() {
                 19 => {
-                    auto_detect_board = true;
+                    auto_detect_board = cart.game_info.is_none();
                     Board::Namco163
                 }
                 210 => match cart.submapper_num() {


### PR DESCRIPTION
Hello, 

Quick context: I've been doing a Rust + Godot rewrite of Sangokushi II: Haō no Tairiku (NES, Namco163), and wanted tetanes for breakpoints. Couldn't get past the title screen on stock tetanes, which dragged me into the mapper 19 code. These four patches are what fell out. Each of which came from cross-referencing tetanes against Nestopia, Mesen2, and FCEUX:

1. Disable variant auto-detection when the ROM is in the CRC database.
2. Drop the $F800 PRG-RAM write protect (this was the one keeping the force selection scene from accepting input --  15,000+ dropped writes in 30s of gameplay).
3. Keep the audio phase accumulator outside sound RAM.
4. Persist PRG-RAM as battery save instead of the 128-byte audio RAM. Auto save state was masking it; `--no-load` shows the failure.

A few questions:

- Patch 2 diverges from Mesen2, which keeps the per-bank lock. If you have evidence bit 6 of $F800 is a real WRAM enable on hardware, happy to keep bit 6 and drop only bits 0–3.
- Patch 1 gates on `cart.game_info.is_none()`, coarser than Mesen2's `DatabaseInfo.Board` check since `GameInfo` has no board field today. Happy to add one if you'd prefer.
- Patch 4 orphans existing `.ciram` files. They only ever held transient audio RAM, but I can add a migration shim if you'd rather not move users silently.

Thanks for tetanes, which is an invaluable tool for me!
