### PR TITLE
fix(cpu): JAM/KIL rewinds PC and stays cycling instead of halting

### DIFF
--- a/tetanes-core/src/cpu/instr.rs
+++ b/tetanes-core/src/cpu/instr.rs
@@ -1442,22 +1442,16 @@ impl Cpu {
 
     // Unofficial opcodes
 
-    /// HLT: Captures all unimplemented opcodes and halts CPU
+    /// JAM/KIL: Rewinds PC and keeps cycling without stopping emulation.
+    ///
+    /// The CPU stays at the JAM address, re-reading the opcode each cycle. For
+    /// addresses in PPU register space ($2000-$3FFF) this auto-increments PPUDATA,
+    /// so the CPU eventually reads a non-JAM byte and resumes normal execution.
+    /// IRQ/NMI are suppressed while jammed (matches real 6502 hardware).
     #[inline(always)]
     pub fn hlt(&mut self) {
-        // Freezes CPU by rewiding and re-executing the bad opcode.
         self.pc = self.pc.wrapping_sub(1);
-        // Prevent IRQ/NMI
         self.clear_irq_flags(IrqFlags::PREV_RUN_IRQ | IrqFlags::PREV_NMI);
-
-        self.corrupted = true;
-        let opcode = usize::from(self.peek(self.pc.wrapping_sub(1)));
-        let instr = Cpu::INSTR_REF[opcode];
-        tracing::error!(
-            "Invalid opcode ${opcode:02X} {:?} #{:?} encountered!",
-            instr.instr,
-            instr.addr_mode,
-        );
     }
 
     /// ISC/ISB: Shortcut for INC then SBC


### PR DESCRIPTION
Match real 6502 behavior: a JAM/KIL opcode keeps the CPU cycling at the same address rather than marking the CPU as corrupted. IRQ/NMI are suppressed while jammed. When the JAM address falls in PPU register space ($2000-$3FFF), each fetch auto-increments PPUDATA, so the CPU eventually reads a non-JAM byte and resumes -- useful for ROMs that trip a JAM as a synchronization tool.

Cross-verified against

- Mesen2 (NesCpu::HLT, NesCpu.cpp:571), 
- FCEUX (KIL handler in ops.inc:402), and 
- Nestopia (Cpu::Jam, NstCpu.cpp:1819)

all three rewind PC by 1 and suppress NMI/IRQ via a jammed flag. tetanes' implementation matches the same pattern.