### PR TITLE
Implement mapper 105

### DIFF
--- a/tetanes-core/src/cart.rs
+++ b/tetanes-core/src/cart.rs
@@ -5,8 +5,9 @@ use crate::{
     fs,
     mapper::{
         self, Axrom, BandaiFCG, Bf909x, Bnrom, Cnrom, ColorDreams, Exrom, Fxrom, Gxrom,
-        JalecoSs88006, Mapper, Mmc1Revision, Namco163, Nina003006, Nrom, Pxrom, SunsoftFme7, Sxrom,
-        Txrom, Uxrom, Vrc6, m024_m026_vrc6::Revision as Vrc6Revision, m034_nina001::Nina001,
+        JalecoSs88006, Mapper, Mmc1Revision, Namco163, NesEvent, Nina003006, Nrom, Pxrom,
+        SunsoftFme7, Sxrom, Txrom, Uxrom, Vrc6, m024_m026_vrc6::Revision as Vrc6Revision,
+        m034_nina001::Nina001,
     },
     mem::{Memory, RamState},
     ppu::Mirroring,
@@ -230,6 +231,12 @@ impl Cart {
             69 => SunsoftFme7::load(&cart, chr_rom, prg_rom)?,
             71 => Bf909x::load(&cart, chr_rom, prg_rom)?,
             79 | 113 | 146 => Nina003006::load(&cart, chr_rom, prg_rom)?,
+            105 => NesEvent::load(
+                &mut cart,
+                chr_rom,
+                prg_rom,
+                [false, false, true, false], // configuration used in actual tournament
+            )?,
             155 => Sxrom::load(&cart, chr_rom, prg_rom, Mmc1Revision::A)?,
             _ => Mapper::none(),
         };
@@ -330,6 +337,7 @@ impl Cart {
             Mapper::SunsoftFme7(sunsoft_fme7) => sunsoft_fme7.chr_rom.len(),
             Mapper::Bf909x(bf909x) => bf909x.chr.len(),
             Mapper::Nina003006(nina003006) => nina003006.chr_rom.len(),
+            Mapper::NesEvent(nes_event) => nes_event.chr.len(),
         }
     }
 

--- a/tetanes-core/src/control_deck.rs
+++ b/tetanes-core/src/control_deck.rs
@@ -400,7 +400,8 @@ impl ControlDeck {
             | Mapper::Nina001(_)
             | Mapper::Gxrom(_)
             | Mapper::SunsoftFme7(_)
-            | Mapper::Nina003006(_) => (),
+            | Mapper::Nina003006(_)
+            | Mapper::NesEvent(_) => (),
         }
     }
 

--- a/tetanes-core/src/mapper.rs
+++ b/tetanes-core/src/mapper.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 
 pub use bandai_fcg::BandaiFCG; // m016, m153, m157, m159
 pub use m000_nrom::Nrom;
-pub use m001_sxrom::{Revision as Mmc1Revision, Sxrom};
+pub use m001_sxrom::Sxrom;
 pub use m002_uxrom::Uxrom;
 pub use m003_cnrom::Cnrom;
 pub use m004_txrom::{Revision as Mmc3Revision, Txrom};
@@ -30,6 +30,7 @@ pub use m066_gxrom::Gxrom;
 pub use m069_sunsoft_fme7::SunsoftFme7;
 pub use m071_bf909x::{Bf909x, Revision as Bf909Revision};
 pub use m079_nina003_006::Nina003006;
+pub use mmc1::{Mmc1, Revision as Mmc1Revision};
 
 pub mod bandai_fcg;
 pub mod m000_nrom;
@@ -51,6 +52,7 @@ pub mod m066_gxrom;
 pub mod m069_sunsoft_fme7;
 pub mod m071_bf909x;
 pub mod m079_nina003_006;
+pub mod mmc1;
 pub mod vrc_irq;
 
 /// Errors that mappers can return.

--- a/tetanes-core/src/mapper.rs
+++ b/tetanes-core/src/mapper.rs
@@ -30,6 +30,7 @@ pub use m066_gxrom::Gxrom;
 pub use m069_sunsoft_fme7::SunsoftFme7;
 pub use m071_bf909x::{Bf909x, Revision as Bf909Revision};
 pub use m079_nina003_006::Nina003006;
+pub use m105_nes_event::NesEvent;
 pub use mmc1::{Mmc1, Revision as Mmc1Revision};
 
 pub mod bandai_fcg;
@@ -52,6 +53,7 @@ pub mod m066_gxrom;
 pub mod m069_sunsoft_fme7;
 pub mod m071_bf909x;
 pub mod m079_nina003_006;
+pub mod m105_nes_event;
 pub mod mmc1;
 pub mod vrc_irq;
 
@@ -138,6 +140,8 @@ pub enum Mapper {
     Bf909x(Bf909x),
     /// `NINA-003`/`NINA-006` (Mapper 079).
     Nina003006(Nina003006),
+    /// `NES-EVENT` (Mapper 105)
+    NesEvent(NesEvent),
 }
 
 /// Implement `From<T>` for `Mapper`.
@@ -187,6 +191,7 @@ impl_from_board!(
     SunsoftFme7(SunsoftFme7),
     Bf909x(Bf909x),
     Nina003006(Nina003006),
+    NesEvent(NesEvent),
 );
 
 /// Implement `Map` function for all `Mapper` variants.
@@ -214,6 +219,7 @@ macro_rules! impl_map {
             Mapper::SunsoftFme7(m) => m.$fn($($args),*),
             Mapper::Bf909x(m) => m.$fn($($args),*),
             Mapper::Nina003006(m) => m.$fn($($args),*),
+            Mapper::NesEvent(m) => m.$fn($($args),*),
         }
     };
 }

--- a/tetanes-core/src/mapper/m001_sxrom.rs
+++ b/tetanes-core/src/mapper/m001_sxrom.rs
@@ -73,7 +73,6 @@ impl Sxrom {
     const PRG_MODE_MASK: u8 = 0x08; // 0b01000
     const CHR_MODE_MASK: u8 = 0x10; // 0b10000
 
-    const DEFAULT_PRG_MODE: u8 = 0x0C; // Mode 3, 16k Fixed Last
     const CHR_BANK_MASK: u8 = 0x1F;
     const PRG_BANK_MASK: u8 = 0x0F;
     const PRG_RAM_DISABLED: u8 = 0x10; // 0b10000
@@ -101,10 +100,10 @@ impl Sxrom {
                 write_just_occurred: 0x00,
                 write_buffer: 0x00,
                 shift_count: 0,
-                prg_ram_disabled: false,
+                prg_ram_disabled: revision == Revision::A,
                 chr_mode: false,
-                prg_mode: false,
-                prg_bank_select: false,
+                prg_mode: true,
+                prg_bank_select: true,
                 last_chr_reg: 0xA000,
                 chr0: 0x00,
                 chr1: 0x00,
@@ -116,18 +115,6 @@ impl Sxrom {
             revision,
             prg_select: cart.prg_rom_size == 0x80000,
         };
-        sxrom.process_register_write(0x8000, Self::DEFAULT_PRG_MODE);
-        sxrom.process_register_write(0xA000, 0x00);
-        sxrom.process_register_write(0xC000, 0x00);
-        sxrom.process_register_write(
-            0xE000,
-            if revision == Revision::BC {
-                0x00
-            } else {
-                Self::PRG_RAM_DISABLED
-            },
-        );
-        sxrom.mmc1.last_chr_reg = 0xA000;
         sxrom.update_state();
         Ok(sxrom.into())
     }

--- a/tetanes-core/src/mapper/m001_sxrom.rs
+++ b/tetanes-core/src/mapper/m001_sxrom.rs
@@ -7,212 +7,12 @@ use crate::{
     cart::Cart,
     common::{Clock, Regional, Reset, ResetKind, Sram},
     fs,
-    mapper::{self, Map, Mapper},
+    mapper::{self, Map, Mapper, Mmc1, Mmc1Revision},
     mem::{Banks, Memory},
     ppu::{CIRam, Mirroring},
 };
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-
-/// MMC1 Revision.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[must_use]
-pub enum Revision {
-    /// MMC1 Revision A
-    A,
-    /// MMC1 Revisions B & C
-    #[default]
-    BC,
-}
-
-/// The `MMC1` chip.
-#[derive(Clone, Serialize, Deserialize)]
-#[must_use]
-pub struct Mmc1 {
-    revision: Revision,
-    write_just_occurred: u8,
-    write_buffer: u8,       // $8000-$FFFF - 5 bit shift register
-    shift_count: u8,        // How many times write_buffer has shifted
-    prg_ram_disabled: bool, // $E000-$FFFF bit 4
-    chr_mode: bool,         // $8000-$9FFF bit 4
-    prg_mode: bool,         // $8000-$9FFF bit 3
-    prg_bank_select: bool,  // $8000-$9FFF bit 2
-    mirroring: Mirroring,   // $8000-$9FFF bits 0-1
-    last_chr_reg: u16,      // Last chr register written to
-    chr0: u8,               // $A000-$BFFF
-    chr1: u8,               // $C000-$DFFF
-    prg: u8,                // $E000-$FFFF bits 0-3
-}
-
-impl Mmc1 {
-    const SHIFT_REG_RESET: u8 = 0x80; // Reset shift register when bit 7 is set
-    const MIRRORING_MASK: u8 = 0x03; // 0b00011
-    const SLOT_SELECT_MASK: u8 = 0x04; // 0b00100
-    const PRG_MODE_MASK: u8 = 0x08; // 0b01000
-    const CHR_MODE_MASK: u8 = 0x10; // 0b10000
-
-    const CHR_BANK_MASK: u8 = 0x1F;
-    const PRG_BANK_MASK: u8 = 0x0F;
-    const PRG_RAM_DISABLED: u8 = 0x10; // 0b10000
-
-    pub fn new(revision: Revision) -> Self {
-        Self {
-            revision,
-            write_just_occurred: 0x00,
-            write_buffer: 0x00,
-            shift_count: 0,
-            prg_ram_disabled: revision == Revision::A,
-            chr_mode: false,
-            prg_mode: true,
-            prg_bank_select: true,
-            mirroring: Mirroring::SingleScreenA,
-            last_chr_reg: 0xA000,
-            chr0: 0x00,
-            chr1: 0x00,
-            prg: 0x00,
-        }
-    }
-
-    /// Reset the shift register write buffer.
-    const fn reset_buffer(&mut self) {
-        self.shift_count = 0;
-        self.write_buffer = 0;
-    }
-
-    const fn process_shift_register_write(&mut self, addr: u16, val: u8) -> bool {
-        // Writes data into a shift register. At every 5th
-        // write, the data is written out to the `SxROM` registers
-        // and the shift register is cleared
-        //
-        // Load Register $8000-$FFFF
-        // 7654 3210
-        // Rxxx xxxD
-        // |       +- Data bit to be shifted into shift register, LSB first
-        // +--------- 1: Reset shift register and write control with (Control OR $0C),
-        //               locking PRG-ROM at $C000-$FFFF to the last bank.
-        //
-        // Control $8000-$9FFF
-        // 43210
-        // CPPMM
-        // |||++- Mirroring (0: one-screen, lower bank; 1: one-screen, upper bank;
-        // |||               2: vertical; 3: horizontal)
-        // |++--- PRG-ROM bank mode (0, 1: switch 32K at $8000, ignoring low bit of bank number;
-        // |                         2: fix first bank at $8000 and switch 16K bank at $C000;
-        // |                         3: fix last bank at $C000 and switch 16K bank at $8000)
-        // +----- CHR-ROM bank mode (0: switch 8K at a time; 1: switch two separate 4K banks)
-        //
-        // CHR bank 0 $A000-$BFFF
-        // 42310
-        // CCCCC
-        // +++++- Select 4K or 8K CHR bank at PPU $0000 (low bit ignored in 8K mode)
-        //
-        // CHR bank 1 $C000-$DFFF
-        // 43210
-        // CCCCC
-        // +++++- Select 4K CHR bank at PPU $1000 (ignored in 8K mode)
-        //
-        // For Mapper001
-        // $A000 and $C000:
-        // 43210
-        // EDCBA
-        // |||||
-        // ||||+- CHR A12
-        // |||+-- CHR A13, if extant (CHR >= 16k)
-        // ||+--- CHR A14, if extant; and PRG-RAM A14, if extant (PRG-RAM = 32k)
-        // |+---- CHR A15, if extant; and PRG-RAM A13, if extant (PRG-RAM >= 16k)
-        // +----- CHR A16, if extant; and PRG-ROM A18, if extant (PRG-ROM = 512k)
-        //
-        // PRG bank $E000-$FFFF
-        // 43210
-        // RPPPP
-        // |++++- Select 16K PRG-ROM bank (low bit ignored in 32K mode)
-        // +----- PRG-RAM chip enable (0: enabled; 1: disabled; ignored on MMC1A)
-
-        if self.write_just_occurred > 0 {
-            return false;
-        }
-        self.write_just_occurred = 2;
-
-        if val & Self::SHIFT_REG_RESET == Self::SHIFT_REG_RESET {
-            self.reset_buffer();
-            self.prg_mode = true;
-            self.prg_bank_select = true;
-            return true;
-        } else {
-            // Move shift register and write lowest bit of val
-            self.write_buffer >>= 1;
-            self.write_buffer |= (val << 4) & 0x10;
-
-            self.shift_count += 1;
-            // Check if its time to write
-            if self.shift_count == 5 {
-                self.process_register_write(addr, self.write_buffer);
-                self.reset_buffer();
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Process register write, extracting registers into flags.
-    const fn process_register_write(&mut self, addr: u16, val: u8) {
-        match addr & 0xE000 {
-            0x8000 => {
-                self.mirroring = match val & Self::MIRRORING_MASK {
-                    0b00 => Mirroring::SingleScreenA,
-                    0b01 => Mirroring::SingleScreenB,
-                    0b10 => Mirroring::Vertical,
-                    _ => Mirroring::Horizontal,
-                };
-                self.prg_bank_select = (val & Self::SLOT_SELECT_MASK) != 0;
-                self.prg_mode = (val & Self::PRG_MODE_MASK) != 0;
-                self.chr_mode = (val & Self::CHR_MODE_MASK) != 0;
-            }
-            0xA000 => {
-                self.last_chr_reg = addr;
-                self.chr0 = val & Self::CHR_BANK_MASK;
-            }
-            0xC000 => {
-                self.last_chr_reg = addr;
-                self.chr1 = val & Self::CHR_BANK_MASK;
-            }
-            0xE000 => {
-                self.prg = val & Self::PRG_BANK_MASK;
-                self.prg_ram_disabled = (val & Self::PRG_RAM_DISABLED) != 0;
-            }
-            _ => (),
-        }
-    }
-
-    #[inline(always)]
-    pub fn prg_ram_enabled(&self) -> bool {
-        self.revision == Revision::A || !self.prg_ram_disabled
-    }
-
-    pub const fn set_revision(&mut self, revision: Revision) {
-        self.revision = revision;
-    }
-}
-
-impl Reset for Mmc1 {
-    fn reset(&mut self, kind: ResetKind) {
-        self.reset_buffer();
-        self.prg_mode = true;
-        self.prg_bank_select = true;
-        if kind == ResetKind::Hard {
-            self.write_just_occurred = 0;
-            self.prg_ram_disabled = false;
-        }
-    }
-}
-
-impl Clock for Mmc1 {
-    fn clock(&mut self) {
-        if self.write_just_occurred > 0 {
-            self.write_just_occurred -= 1;
-        }
-    }
-}
 
 /// `SxROM`/`MMC1` (Mapper 001).
 #[derive(Clone, Serialize, Deserialize)]
@@ -245,7 +45,7 @@ impl Sxrom {
         cart: &Cart,
         chr_rom: Memory<Box<[u8]>>,
         prg_rom: Memory<Box<[u8]>>,
-        revision: Revision,
+        revision: Mmc1Revision,
     ) -> Result<Mapper, mapper::Error> {
         let (chr, has_chr_ram) = cart.chr_rom_or_ram(chr_rom, Self::CHR_RAM_SIZE);
         let prg_ram = cart.prg_ram_or_default(Self::PRG_RAM_SIZE);
@@ -408,27 +208,6 @@ impl std::fmt::Debug for Sxrom {
             .field("chr_banks", &self.chr_banks)
             .field("prg_ram_banks", &self.prg_ram_banks)
             .field("prg_rom_banks", &self.prg_rom_banks)
-            .finish()
-    }
-}
-
-impl std::fmt::Debug for Mmc1 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Mmc1")
-            .field("revision", &self.revision)
-            .field("write_just_occurred", &self.write_just_occurred)
-            .field("write_buffer", &format_args!("0b{:08b}", self.write_buffer))
-            .field("shift_count", &self.shift_count)
-            .field("prg_ram_disabled", &self.prg_ram_disabled)
-            .field("chr_mode", &self.chr_mode)
-            .field("prg_mode", &self.prg_mode)
-            .field("prg_bank_select", &self.prg_bank_select)
-            .field("mirroring", &self.mirroring)
-            .field("last_chr_reg", &self.last_chr_reg)
-            .field("chr0", &format_args!("${:02X}", self.chr0))
-            .field("chr1", &format_args!("${:02X}", self.chr1))
-            .field("prg", &format_args!("${:02X}", self.prg))
-            .field("prg_ram_enabled", &self.prg_ram_enabled())
             .finish()
     }
 }

--- a/tetanes-core/src/mapper/m001_sxrom.rs
+++ b/tetanes-core/src/mapper/m001_sxrom.rs
@@ -25,16 +25,16 @@ pub enum Revision {
     BC,
 }
 
-/// `SxROM` registers.
+/// The `MMC1` chip.
 #[derive(Clone, Serialize, Deserialize)]
 #[must_use]
-pub struct Regs {
+pub struct Mmc1 {
     write_just_occurred: u8,
     write_buffer: u8,       // $8000-$FFFF - 5 bit shift register
     shift_count: u8,        // How many times write_buffer has shifted
     prg_ram_disabled: bool, // $E000-$FFFF bit 4
     chr_mode: bool,         // $8000-$9FFF bit 4
-    prg_mode: bool,         // $8000-$9FFF bits 3
+    prg_mode: bool,         // $8000-$9FFF bit 3
     prg_bank_select: bool,  // $8000-$9FFF bit 2
     last_chr_reg: u16,      // Last chr register written to
     chr0: u8,               // $A000-$BFFF
@@ -52,7 +52,7 @@ pub struct Sxrom {
     pub chr_banks: Banks,
     pub prg_ram_banks: Banks,
     pub prg_rom_banks: Banks,
-    pub regs: Regs,
+    pub mmc1: Mmc1,
     pub has_chr_ram: bool,
     pub submapper_num: u8,
     pub mirroring: Mirroring,
@@ -97,7 +97,7 @@ impl Sxrom {
             chr_banks,
             prg_ram_banks,
             prg_rom_banks,
-            regs: Regs {
+            mmc1: Mmc1 {
                 write_just_occurred: 0x00,
                 write_buffer: 0x00,
                 shift_count: 0,
@@ -127,15 +127,15 @@ impl Sxrom {
                 Self::PRG_RAM_DISABLED
             },
         );
-        sxrom.regs.last_chr_reg = 0xA000;
+        sxrom.mmc1.last_chr_reg = 0xA000;
         sxrom.update_state();
         Ok(sxrom.into())
     }
 
     /// Reset the shift register write buffer.
     const fn reset_buffer(&mut self) {
-        self.regs.shift_count = 0;
-        self.regs.write_buffer = 0;
+        self.mmc1.shift_count = 0;
+        self.mmc1.write_buffer = 0;
     }
 
     /// Process register write, extracting registers into flags.
@@ -148,21 +148,21 @@ impl Sxrom {
                     0b10 => Mirroring::Vertical,
                     _ => Mirroring::Horizontal,
                 };
-                self.regs.prg_bank_select = (val & Self::SLOT_SELECT_MASK) != 0;
-                self.regs.prg_mode = (val & Self::PRG_MODE_MASK) != 0;
-                self.regs.chr_mode = (val & Self::CHR_MODE_MASK) != 0;
+                self.mmc1.prg_bank_select = (val & Self::SLOT_SELECT_MASK) != 0;
+                self.mmc1.prg_mode = (val & Self::PRG_MODE_MASK) != 0;
+                self.mmc1.chr_mode = (val & Self::CHR_MODE_MASK) != 0;
             }
             0xA000 => {
-                self.regs.last_chr_reg = addr;
-                self.regs.chr0 = val & Self::CHR_BANK_MASK;
+                self.mmc1.last_chr_reg = addr;
+                self.mmc1.chr0 = val & Self::CHR_BANK_MASK;
             }
             0xC000 => {
-                self.regs.last_chr_reg = addr;
-                self.regs.chr1 = val & Self::CHR_BANK_MASK;
+                self.mmc1.last_chr_reg = addr;
+                self.mmc1.chr1 = val & Self::CHR_BANK_MASK;
             }
             0xE000 => {
-                self.regs.prg = val & Self::PRG_BANK_MASK;
-                self.regs.prg_ram_disabled = (val & Self::PRG_RAM_DISABLED) != 0;
+                self.mmc1.prg = val & Self::PRG_BANK_MASK;
+                self.mmc1.prg_ram_disabled = (val & Self::PRG_RAM_DISABLED) != 0;
             }
             _ => (),
         }
@@ -170,10 +170,10 @@ impl Sxrom {
 
     /// Update internal state based on register flags.
     pub fn update_state(&mut self) {
-        let extra_reg = if self.regs.last_chr_reg == 0xC000 && self.regs.chr_mode {
-            self.regs.chr1
+        let extra_reg = if self.mmc1.last_chr_reg == 0xC000 && self.mmc1.chr_mode {
+            self.mmc1.chr1
         } else {
-            self.regs.chr0
+            self.mmc1.chr0
         };
         let prg_bank_select = if self.prg_select {
             extra_reg & Self::CHR_MODE_MASK
@@ -184,34 +184,34 @@ impl Sxrom {
         if self.submapper_num == 5 {
             // Fixed PRG SEROM, SHROM, SH1ROM use a fixed 32k PRG-ROM with no banking support.
             self.prg_rom_banks.set_range(0, 1, 0);
-        } else if self.regs.prg_mode {
-            if self.regs.prg_bank_select {
+        } else if self.mmc1.prg_mode {
+            if self.mmc1.prg_bank_select {
                 self.prg_rom_banks
-                    .set(0, (self.regs.prg | prg_bank_select).into());
+                    .set(0, (self.mmc1.prg | prg_bank_select).into());
                 self.prg_rom_banks
                     .set(1, (Self::PRG_BANK_MASK | prg_bank_select).into());
             } else {
                 self.prg_rom_banks.set(1, prg_bank_select.into());
                 self.prg_rom_banks
-                    .set(1, (self.regs.prg | prg_bank_select).into());
+                    .set(1, (self.mmc1.prg | prg_bank_select).into());
             }
         } else {
             self.prg_rom_banks
-                .set_range(0, 1, ((self.regs.prg & 0xFE) | prg_bank_select).into()); // ignore low bit
+                .set_range(0, 1, ((self.mmc1.prg & 0xFE) | prg_bank_select).into()); // ignore low bit
         }
 
-        if self.regs.chr_mode {
-            self.chr_banks.set(0, self.regs.chr0.into());
-            self.chr_banks.set(1, self.regs.chr1.into());
+        if self.mmc1.chr_mode {
+            self.chr_banks.set(0, self.mmc1.chr0.into());
+            self.chr_banks.set(1, self.mmc1.chr1.into());
         } else {
-            self.chr_banks.set(0, (self.regs.chr0 & 0x1E).into()); // ignore low bit
-            self.chr_banks.set(1, ((self.regs.chr0 & 0x1E) + 1).into()); // ignore low bit
+            self.chr_banks.set(0, (self.mmc1.chr0 & 0x1E).into()); // ignore low bit
+            self.chr_banks.set(1, ((self.mmc1.chr0 & 0x1E) + 1).into()); // ignore low bit
         }
     }
 
     #[inline(always)]
     pub fn prg_ram_enabled(&self) -> bool {
-        self.revision == Revision::A || !self.regs.prg_ram_disabled
+        self.revision == Revision::A || !self.mmc1.prg_ram_disabled
     }
 
     pub const fn set_revision(&mut self, revision: Revision) {
@@ -313,25 +313,25 @@ impl Map for Sxrom {
                 // |++++- Select 16K PRG-ROM bank (low bit ignored in 32K mode)
                 // +----- PRG-RAM chip enable (0: enabled; 1: disabled; ignored on MMC1A)
 
-                if self.regs.write_just_occurred > 0 {
+                if self.mmc1.write_just_occurred > 0 {
                     return;
                 }
-                self.regs.write_just_occurred = 2;
+                self.mmc1.write_just_occurred = 2;
 
                 if val & Self::SHIFT_REG_RESET == Self::SHIFT_REG_RESET {
                     self.reset_buffer();
-                    self.regs.prg_mode = true;
-                    self.regs.prg_bank_select = true;
+                    self.mmc1.prg_mode = true;
+                    self.mmc1.prg_bank_select = true;
                     self.update_state();
                 } else {
                     // Move shift register and write lowest bit of val
-                    self.regs.write_buffer >>= 1;
-                    self.regs.write_buffer |= (val << 4) & 0x10;
+                    self.mmc1.write_buffer >>= 1;
+                    self.mmc1.write_buffer |= (val << 4) & 0x10;
 
-                    self.regs.shift_count += 1;
+                    self.mmc1.shift_count += 1;
                     // Check if its time to write
-                    if self.regs.shift_count == 5 {
-                        self.process_register_write(addr, self.regs.write_buffer);
+                    if self.mmc1.shift_count == 5 {
+                        self.process_register_write(addr, self.mmc1.write_buffer);
                         self.update_state();
                         self.reset_buffer();
                     }
@@ -351,20 +351,20 @@ impl Map for Sxrom {
 impl Reset for Sxrom {
     fn reset(&mut self, kind: ResetKind) {
         self.reset_buffer();
-        self.regs.prg_mode = true;
-        self.regs.prg_bank_select = true;
+        self.mmc1.prg_mode = true;
+        self.mmc1.prg_bank_select = true;
         self.update_state();
         if kind == ResetKind::Hard {
-            self.regs.write_just_occurred = 0;
-            self.regs.prg_ram_disabled = false;
+            self.mmc1.write_just_occurred = 0;
+            self.mmc1.prg_ram_disabled = false;
         }
     }
 }
 
 impl Clock for Sxrom {
     fn clock(&mut self) {
-        if self.regs.write_just_occurred > 0 {
-            self.regs.write_just_occurred -= 1;
+        if self.mmc1.write_just_occurred > 0 {
+            self.mmc1.write_just_occurred -= 1;
         }
     }
 }
@@ -386,7 +386,7 @@ impl Regional for Sxrom {}
 impl std::fmt::Debug for Sxrom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SxRom")
-            .field("regs", &self.regs)
+            .field("mmc1", &self.mmc1)
             .field("submapper_num", &self.submapper_num)
             .field("mirroring", &self.mirroring)
             .field("revision", &self.revision)
@@ -399,9 +399,9 @@ impl std::fmt::Debug for Sxrom {
     }
 }
 
-impl std::fmt::Debug for Regs {
+impl std::fmt::Debug for Mmc1 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("SxRegs")
+        f.debug_struct("Mmc1")
             .field("write_just_occurred", &self.write_just_occurred)
             .field("write_buffer", &format_args!("0b{:08b}", self.write_buffer))
             .field("shift_count", &self.shift_count)

--- a/tetanes-core/src/mapper/m001_sxrom.rs
+++ b/tetanes-core/src/mapper/m001_sxrom.rs
@@ -29,6 +29,7 @@ pub enum Revision {
 #[derive(Clone, Serialize, Deserialize)]
 #[must_use]
 pub struct Mmc1 {
+    revision: Revision,
     write_just_occurred: u8,
     write_buffer: u8,       // $8000-$FFFF - 5 bit shift register
     shift_count: u8,        // How many times write_buffer has shifted
@@ -36,10 +37,181 @@ pub struct Mmc1 {
     chr_mode: bool,         // $8000-$9FFF bit 4
     prg_mode: bool,         // $8000-$9FFF bit 3
     prg_bank_select: bool,  // $8000-$9FFF bit 2
+    mirroring: Mirroring,   // $8000-$9FFF bits 0-1
     last_chr_reg: u16,      // Last chr register written to
     chr0: u8,               // $A000-$BFFF
     chr1: u8,               // $C000-$DFFF
     prg: u8,                // $E000-$FFFF bits 0-3
+}
+
+impl Mmc1 {
+    const SHIFT_REG_RESET: u8 = 0x80; // Reset shift register when bit 7 is set
+    const MIRRORING_MASK: u8 = 0x03; // 0b00011
+    const SLOT_SELECT_MASK: u8 = 0x04; // 0b00100
+    const PRG_MODE_MASK: u8 = 0x08; // 0b01000
+    const CHR_MODE_MASK: u8 = 0x10; // 0b10000
+
+    const CHR_BANK_MASK: u8 = 0x1F;
+    const PRG_BANK_MASK: u8 = 0x0F;
+    const PRG_RAM_DISABLED: u8 = 0x10; // 0b10000
+
+    pub fn new(revision: Revision) -> Self {
+        Self {
+            revision,
+            write_just_occurred: 0x00,
+            write_buffer: 0x00,
+            shift_count: 0,
+            prg_ram_disabled: revision == Revision::A,
+            chr_mode: false,
+            prg_mode: true,
+            prg_bank_select: true,
+            mirroring: Mirroring::SingleScreenA,
+            last_chr_reg: 0xA000,
+            chr0: 0x00,
+            chr1: 0x00,
+            prg: 0x00,
+        }
+    }
+
+    /// Reset the shift register write buffer.
+    const fn reset_buffer(&mut self) {
+        self.shift_count = 0;
+        self.write_buffer = 0;
+    }
+
+    const fn process_shift_register_write(&mut self, addr: u16, val: u8) -> bool {
+        // Writes data into a shift register. At every 5th
+        // write, the data is written out to the `SxROM` registers
+        // and the shift register is cleared
+        //
+        // Load Register $8000-$FFFF
+        // 7654 3210
+        // Rxxx xxxD
+        // |       +- Data bit to be shifted into shift register, LSB first
+        // +--------- 1: Reset shift register and write control with (Control OR $0C),
+        //               locking PRG-ROM at $C000-$FFFF to the last bank.
+        //
+        // Control $8000-$9FFF
+        // 43210
+        // CPPMM
+        // |||++- Mirroring (0: one-screen, lower bank; 1: one-screen, upper bank;
+        // |||               2: vertical; 3: horizontal)
+        // |++--- PRG-ROM bank mode (0, 1: switch 32K at $8000, ignoring low bit of bank number;
+        // |                         2: fix first bank at $8000 and switch 16K bank at $C000;
+        // |                         3: fix last bank at $C000 and switch 16K bank at $8000)
+        // +----- CHR-ROM bank mode (0: switch 8K at a time; 1: switch two separate 4K banks)
+        //
+        // CHR bank 0 $A000-$BFFF
+        // 42310
+        // CCCCC
+        // +++++- Select 4K or 8K CHR bank at PPU $0000 (low bit ignored in 8K mode)
+        //
+        // CHR bank 1 $C000-$DFFF
+        // 43210
+        // CCCCC
+        // +++++- Select 4K CHR bank at PPU $1000 (ignored in 8K mode)
+        //
+        // For Mapper001
+        // $A000 and $C000:
+        // 43210
+        // EDCBA
+        // |||||
+        // ||||+- CHR A12
+        // |||+-- CHR A13, if extant (CHR >= 16k)
+        // ||+--- CHR A14, if extant; and PRG-RAM A14, if extant (PRG-RAM = 32k)
+        // |+---- CHR A15, if extant; and PRG-RAM A13, if extant (PRG-RAM >= 16k)
+        // +----- CHR A16, if extant; and PRG-ROM A18, if extant (PRG-ROM = 512k)
+        //
+        // PRG bank $E000-$FFFF
+        // 43210
+        // RPPPP
+        // |++++- Select 16K PRG-ROM bank (low bit ignored in 32K mode)
+        // +----- PRG-RAM chip enable (0: enabled; 1: disabled; ignored on MMC1A)
+
+        if self.write_just_occurred > 0 {
+            return false;
+        }
+        self.write_just_occurred = 2;
+
+        if val & Self::SHIFT_REG_RESET == Self::SHIFT_REG_RESET {
+            self.reset_buffer();
+            self.prg_mode = true;
+            self.prg_bank_select = true;
+            return true;
+        } else {
+            // Move shift register and write lowest bit of val
+            self.write_buffer >>= 1;
+            self.write_buffer |= (val << 4) & 0x10;
+
+            self.shift_count += 1;
+            // Check if its time to write
+            if self.shift_count == 5 {
+                self.process_register_write(addr, self.write_buffer);
+                self.reset_buffer();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Process register write, extracting registers into flags.
+    const fn process_register_write(&mut self, addr: u16, val: u8) {
+        match addr & 0xE000 {
+            0x8000 => {
+                self.mirroring = match val & Self::MIRRORING_MASK {
+                    0b00 => Mirroring::SingleScreenA,
+                    0b01 => Mirroring::SingleScreenB,
+                    0b10 => Mirroring::Vertical,
+                    _ => Mirroring::Horizontal,
+                };
+                self.prg_bank_select = (val & Self::SLOT_SELECT_MASK) != 0;
+                self.prg_mode = (val & Self::PRG_MODE_MASK) != 0;
+                self.chr_mode = (val & Self::CHR_MODE_MASK) != 0;
+            }
+            0xA000 => {
+                self.last_chr_reg = addr;
+                self.chr0 = val & Self::CHR_BANK_MASK;
+            }
+            0xC000 => {
+                self.last_chr_reg = addr;
+                self.chr1 = val & Self::CHR_BANK_MASK;
+            }
+            0xE000 => {
+                self.prg = val & Self::PRG_BANK_MASK;
+                self.prg_ram_disabled = (val & Self::PRG_RAM_DISABLED) != 0;
+            }
+            _ => (),
+        }
+    }
+
+    #[inline(always)]
+    pub fn prg_ram_enabled(&self) -> bool {
+        self.revision == Revision::A || !self.prg_ram_disabled
+    }
+
+    pub const fn set_revision(&mut self, revision: Revision) {
+        self.revision = revision;
+    }
+}
+
+impl Reset for Mmc1 {
+    fn reset(&mut self, kind: ResetKind) {
+        self.reset_buffer();
+        self.prg_mode = true;
+        self.prg_bank_select = true;
+        if kind == ResetKind::Hard {
+            self.write_just_occurred = 0;
+            self.prg_ram_disabled = false;
+        }
+    }
+}
+
+impl Clock for Mmc1 {
+    fn clock(&mut self) {
+        if self.write_just_occurred > 0 {
+            self.write_just_occurred -= 1;
+        }
+    }
 }
 
 /// `SxROM`/`MMC1` (Mapper 001).
@@ -55,8 +227,6 @@ pub struct Sxrom {
     pub mmc1: Mmc1,
     pub has_chr_ram: bool,
     pub submapper_num: u8,
-    pub mirroring: Mirroring,
-    pub revision: Revision,
     pub prg_select: bool,
 }
 
@@ -67,15 +237,8 @@ impl Sxrom {
     const PRG_RAM_SIZE: usize = 32 * 1024; // 32K is safely compatible sans NES 2.0 header
     const CHR_RAM_SIZE: usize = 8 * 1024;
 
-    const SHIFT_REG_RESET: u8 = 0x80; // Reset shift register when bit 7 is set
-    const MIRRORING_MASK: u8 = 0x03; // 0b00011
-    const SLOT_SELECT_MASK: u8 = 0x04; // 0b00100
-    const PRG_MODE_MASK: u8 = 0x08; // 0b01000
-    const CHR_MODE_MASK: u8 = 0x10; // 0b10000
-
-    const CHR_BANK_MASK: u8 = 0x1F;
     const PRG_BANK_MASK: u8 = 0x0F;
-    const PRG_RAM_DISABLED: u8 = 0x10; // 0b10000
+    const PRG_BANK_SELECT_MASK: u8 = 0x10; // 0b10000
 
     /// Load `Sxrom` from `Cart`.
     pub fn load(
@@ -96,63 +259,13 @@ impl Sxrom {
             chr_banks,
             prg_ram_banks,
             prg_rom_banks,
-            mmc1: Mmc1 {
-                write_just_occurred: 0x00,
-                write_buffer: 0x00,
-                shift_count: 0,
-                prg_ram_disabled: revision == Revision::A,
-                chr_mode: false,
-                prg_mode: true,
-                prg_bank_select: true,
-                last_chr_reg: 0xA000,
-                chr0: 0x00,
-                chr1: 0x00,
-                prg: 0x00,
-            },
+            mmc1: Mmc1::new(revision),
             has_chr_ram,
             submapper_num: cart.submapper_num(),
-            mirroring: Mirroring::SingleScreenA,
-            revision,
             prg_select: cart.prg_rom_size == 0x80000,
         };
         sxrom.update_state();
         Ok(sxrom.into())
-    }
-
-    /// Reset the shift register write buffer.
-    const fn reset_buffer(&mut self) {
-        self.mmc1.shift_count = 0;
-        self.mmc1.write_buffer = 0;
-    }
-
-    /// Process register write, extracting registers into flags.
-    const fn process_register_write(&mut self, addr: u16, val: u8) {
-        match addr & 0xE000 {
-            0x8000 => {
-                self.mirroring = match val & Self::MIRRORING_MASK {
-                    0b00 => Mirroring::SingleScreenA,
-                    0b01 => Mirroring::SingleScreenB,
-                    0b10 => Mirroring::Vertical,
-                    _ => Mirroring::Horizontal,
-                };
-                self.mmc1.prg_bank_select = (val & Self::SLOT_SELECT_MASK) != 0;
-                self.mmc1.prg_mode = (val & Self::PRG_MODE_MASK) != 0;
-                self.mmc1.chr_mode = (val & Self::CHR_MODE_MASK) != 0;
-            }
-            0xA000 => {
-                self.mmc1.last_chr_reg = addr;
-                self.mmc1.chr0 = val & Self::CHR_BANK_MASK;
-            }
-            0xC000 => {
-                self.mmc1.last_chr_reg = addr;
-                self.mmc1.chr1 = val & Self::CHR_BANK_MASK;
-            }
-            0xE000 => {
-                self.mmc1.prg = val & Self::PRG_BANK_MASK;
-                self.mmc1.prg_ram_disabled = (val & Self::PRG_RAM_DISABLED) != 0;
-            }
-            _ => (),
-        }
     }
 
     /// Update internal state based on register flags.
@@ -163,7 +276,7 @@ impl Sxrom {
             self.mmc1.chr0
         };
         let prg_bank_select = if self.prg_select {
-            extra_reg & Self::CHR_MODE_MASK
+            extra_reg & Self::PRG_BANK_SELECT_MASK
         } else {
             0x00
         };
@@ -195,15 +308,6 @@ impl Sxrom {
             self.chr_banks.set(1, ((self.mmc1.chr0 & 0x1E) + 1).into()); // ignore low bit
         }
     }
-
-    #[inline(always)]
-    pub fn prg_ram_enabled(&self) -> bool {
-        self.revision == Revision::A || !self.mmc1.prg_ram_disabled
-    }
-
-    pub const fn set_revision(&mut self, revision: Revision) {
-        self.revision = revision;
-    }
 }
 
 impl Map for Sxrom {
@@ -217,7 +321,7 @@ impl Map for Sxrom {
     fn chr_peek(&self, addr: u16, ciram: &CIRam) -> u8 {
         match addr {
             0x0000..=0x1FFF => self.chr[self.chr_banks.translate(addr)],
-            0x2000..=0x3EFF => ciram.peek(addr, self.mirroring),
+            0x2000..=0x3EFF => ciram.peek(addr, self.mirroring()),
             _ => 0,
         }
     }
@@ -226,7 +330,7 @@ impl Map for Sxrom {
     #[inline(always)]
     fn prg_peek(&self, addr: u16) -> u8 {
         match addr {
-            0x6000..=0x7FFF if self.prg_ram_enabled() => {
+            0x6000..=0x7FFF if self.mmc1.prg_ram_enabled() => {
                 self.prg_ram[self.prg_ram_banks.translate(addr)]
             }
             0x8000..=0xFFFF => self.prg_rom[self.prg_rom_banks.translate(addr)],
@@ -239,7 +343,7 @@ impl Map for Sxrom {
     fn chr_write(&mut self, addr: u16, val: u8, ciram: &mut CIRam) {
         match addr {
             0x0000..=0x1FFF if self.has_chr_ram => self.chr[self.chr_banks.translate(addr)] = val,
-            0x2000..=0x3EFF => ciram.write(addr, val, self.mirroring),
+            0x2000..=0x3EFF => ciram.write(addr, val, self.mirroring()),
             _ => (),
         }
     }
@@ -248,80 +352,13 @@ impl Map for Sxrom {
     #[inline(always)]
     fn prg_write(&mut self, addr: u16, val: u8) {
         match addr {
-            0x6000..=0x7FFF if self.prg_ram_enabled() => {
+            0x6000..=0x7FFF if self.mmc1.prg_ram_enabled() => {
                 self.prg_ram[self.prg_ram_banks.translate(addr)] = val;
             }
             0x8000..=0xFFFF => {
-                // Writes data into a shift register. At every 5th
-                // write, the data is written out to the `SxROM` registers
-                // and the shift register is cleared
-                //
-                // Load Register $8000-$FFFF
-                // 7654 3210
-                // Rxxx xxxD
-                // |       +- Data bit to be shifted into shift register, LSB first
-                // +--------- 1: Reset shift register and write control with (Control OR $0C),
-                //               locking PRG-ROM at $C000-$FFFF to the last bank.
-                //
-                // Control $8000-$9FFF
-                // 43210
-                // CPPMM
-                // |||++- Mirroring (0: one-screen, lower bank; 1: one-screen, upper bank;
-                // |||               2: vertical; 3: horizontal)
-                // |++--- PRG-ROM bank mode (0, 1: switch 32K at $8000, ignoring low bit of bank number;
-                // |                         2: fix first bank at $8000 and switch 16K bank at $C000;
-                // |                         3: fix last bank at $C000 and switch 16K bank at $8000)
-                // +----- CHR-ROM bank mode (0: switch 8K at a time; 1: switch two separate 4K banks)
-                //
-                // CHR bank 0 $A000-$BFFF
-                // 42310
-                // CCCCC
-                // +++++- Select 4K or 8K CHR bank at PPU $0000 (low bit ignored in 8K mode)
-                //
-                // CHR bank 1 $C000-$DFFF
-                // 43210
-                // CCCCC
-                // +++++- Select 4K CHR bank at PPU $1000 (ignored in 8K mode)
-                //
-                // For Mapper001
-                // $A000 and $C000:
-                // 43210
-                // EDCBA
-                // |||||
-                // ||||+- CHR A12
-                // |||+-- CHR A13, if extant (CHR >= 16k)
-                // ||+--- CHR A14, if extant; and PRG-RAM A14, if extant (PRG-RAM = 32k)
-                // |+---- CHR A15, if extant; and PRG-RAM A13, if extant (PRG-RAM >= 16k)
-                // +----- CHR A16, if extant; and PRG-ROM A18, if extant (PRG-ROM = 512k)
-                //
-                // PRG bank $E000-$FFFF
-                // 43210
-                // RPPPP
-                // |++++- Select 16K PRG-ROM bank (low bit ignored in 32K mode)
-                // +----- PRG-RAM chip enable (0: enabled; 1: disabled; ignored on MMC1A)
-
-                if self.mmc1.write_just_occurred > 0 {
-                    return;
-                }
-                self.mmc1.write_just_occurred = 2;
-
-                if val & Self::SHIFT_REG_RESET == Self::SHIFT_REG_RESET {
-                    self.reset_buffer();
-                    self.mmc1.prg_mode = true;
-                    self.mmc1.prg_bank_select = true;
+                let written = self.mmc1.process_shift_register_write(addr, val);
+                if written {
                     self.update_state();
-                } else {
-                    // Move shift register and write lowest bit of val
-                    self.mmc1.write_buffer >>= 1;
-                    self.mmc1.write_buffer |= (val << 4) & 0x10;
-
-                    self.mmc1.shift_count += 1;
-                    // Check if its time to write
-                    if self.mmc1.shift_count == 5 {
-                        self.process_register_write(addr, self.mmc1.write_buffer);
-                        self.update_state();
-                        self.reset_buffer();
-                    }
                 }
             }
             _ => (),
@@ -331,28 +368,20 @@ impl Map for Sxrom {
     /// Returns the current [`Mirroring`] mode.
     #[inline(always)]
     fn mirroring(&self) -> Mirroring {
-        self.mirroring
+        self.mmc1.mirroring
     }
 }
 
 impl Reset for Sxrom {
     fn reset(&mut self, kind: ResetKind) {
-        self.reset_buffer();
-        self.mmc1.prg_mode = true;
-        self.mmc1.prg_bank_select = true;
+        self.mmc1.reset(kind);
         self.update_state();
-        if kind == ResetKind::Hard {
-            self.mmc1.write_just_occurred = 0;
-            self.mmc1.prg_ram_disabled = false;
-        }
     }
 }
 
 impl Clock for Sxrom {
     fn clock(&mut self) {
-        if self.mmc1.write_just_occurred > 0 {
-            self.mmc1.write_just_occurred -= 1;
-        }
+        self.mmc1.clock();
     }
 }
 
@@ -375,12 +404,9 @@ impl std::fmt::Debug for Sxrom {
         f.debug_struct("SxRom")
             .field("mmc1", &self.mmc1)
             .field("submapper_num", &self.submapper_num)
-            .field("mirroring", &self.mirroring)
-            .field("revision", &self.revision)
             .field("prg_select", &self.prg_select)
             .field("chr_banks", &self.chr_banks)
             .field("prg_ram_banks", &self.prg_ram_banks)
-            .field("prg_ram_enabled", &self.prg_ram_enabled())
             .field("prg_rom_banks", &self.prg_rom_banks)
             .finish()
     }
@@ -389,6 +415,7 @@ impl std::fmt::Debug for Sxrom {
 impl std::fmt::Debug for Mmc1 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Mmc1")
+            .field("revision", &self.revision)
             .field("write_just_occurred", &self.write_just_occurred)
             .field("write_buffer", &format_args!("0b{:08b}", self.write_buffer))
             .field("shift_count", &self.shift_count)
@@ -396,10 +423,12 @@ impl std::fmt::Debug for Mmc1 {
             .field("chr_mode", &self.chr_mode)
             .field("prg_mode", &self.prg_mode)
             .field("prg_bank_select", &self.prg_bank_select)
+            .field("mirroring", &self.mirroring)
             .field("last_chr_reg", &self.last_chr_reg)
             .field("chr0", &format_args!("${:02X}", self.chr0))
             .field("chr1", &format_args!("${:02X}", self.chr1))
             .field("prg", &format_args!("${:02X}", self.prg))
+            .field("prg_ram_enabled", &self.prg_ram_enabled())
             .finish()
     }
 }

--- a/tetanes-core/src/mapper/m105_nes_event.rs
+++ b/tetanes-core/src/mapper/m105_nes_event.rs
@@ -1,0 +1,264 @@
+//! `NES-EVENT`/`MMC1` (Mapper 105).
+//!
+//! <https://www.nesdev.org/w/index.php/NES-EVENT>
+//! <https://www.nesdev.org/w/index.php/MMC1>
+
+use crate::{
+    cart::Cart,
+    common::{Clock, Regional, Reset, ResetKind, Sram},
+    mapper::{
+        self, Map, Mapper,
+        mmc1::{self, Mmc1},
+    },
+    mem::{Banks, Memory},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BankSwitchingLock {
+    LockedPending0,
+    LockedPending1,
+    Unlocked,
+}
+
+impl BankSwitchingLock {
+    const fn new() -> Self {
+        Self::LockedPending0
+    }
+
+    const fn locked(&self) -> bool {
+        !matches!(self, BankSwitchingLock::Unlocked)
+    }
+
+    const fn write(&mut self, value: bool) {
+        match (&self, value) {
+            (&BankSwitchingLock::LockedPending0, false) => {
+                *self = BankSwitchingLock::LockedPending1
+            }
+            (&BankSwitchingLock::LockedPending1, true) => *self = BankSwitchingLock::Unlocked,
+            _ => {}
+        }
+    }
+}
+
+impl Default for BankSwitchingLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Reset for BankSwitchingLock {
+    fn reset(&mut self, _kind: ResetKind) {
+        *self = Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Timer {
+    started: bool,
+    value: u32,
+    target_high_byte: u8,
+}
+
+impl Timer {
+    fn new(switches: [bool; 4]) -> Self {
+        Self {
+            started: false,
+            value: 0,
+            target_high_byte: (1 << 5)
+                | (u8::from(switches[3]) << 4)
+                | (u8::from(switches[2]) << 3)
+                | (u8::from(switches[1]) << 2)
+                | (u8::from(switches[0]) << 1),
+        }
+    }
+
+    const fn start(&mut self) {
+        if !self.started {
+            self.started = true;
+            self.value = 0;
+        }
+    }
+
+    const fn stop(&mut self) {
+        self.started = false;
+    }
+
+    const fn irq_pending(&self) -> bool {
+        self.value.to_le_bytes()[3] == self.target_high_byte
+    }
+}
+
+impl Reset for Timer {
+    fn reset(&mut self, _kind: ResetKind) {
+        self.started = false;
+        self.value = 0;
+    }
+}
+
+impl Clock for Timer {
+    fn clock(&mut self) {
+        if !self.started {
+            return;
+        }
+
+        self.value += 1;
+        if self.irq_pending() {
+            self.stop();
+        }
+    }
+}
+
+/// `NES-EVENT`/`MMC1` (Mapper 105).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[must_use]
+pub struct NesEvent {
+    pub chr: Memory<Box<[u8]>>,
+    pub prg_rom: Memory<Box<[u8]>>,
+    pub prg_ram: Memory<Box<[u8]>>,
+    pub prg_rom_banks: Banks,
+    pub mmc1: Mmc1,
+    pub bank_switching_lock: BankSwitchingLock,
+    pub timer: Timer,
+    pub has_chr_ram: bool,
+}
+
+impl NesEvent {
+    const PRG_WINDOW: usize = 16 * 1024;
+    const PRG_RAM_SIZE: usize = 8 * 1024;
+    const CHR_RAM_SIZE: usize = 8 * 1024;
+
+    const INNER_BANK_MASK: u8 = 0b111;
+    const OUTER_BANK_MASK: u8 = 0b1000;
+
+    /// Load `NesEvent` from `Cart`.
+    pub fn load(
+        cart: &mut Cart,
+        chr_rom: Memory<Box<[u8]>>,
+        prg_rom: Memory<Box<[u8]>>,
+        switches: [bool; 4],
+    ) -> Result<Mapper, mapper::Error> {
+        let (chr, has_chr_ram) = cart.chr_rom_or_ram(chr_rom, Self::CHR_RAM_SIZE);
+        let prg_ram = cart.prg_ram_or_default(Self::PRG_RAM_SIZE);
+        let mut nes_event = Self {
+            chr,
+            prg_rom,
+            prg_ram,
+            prg_rom_banks: Banks::new(0x8000, 0xFFFF, cart.prg_rom.len(), Self::PRG_WINDOW)?,
+            mmc1: Mmc1::new(mmc1::Revision::BC),
+            bank_switching_lock: BankSwitchingLock::new(),
+            timer: Timer::new(switches),
+            has_chr_ram,
+        };
+        nes_event.update_state();
+        Ok(nes_event.into())
+    }
+
+    /// Update internal state based on register flags.
+    pub fn update_state(&mut self) {
+        let timer_control = self.mmc1.chr0 & 0b10000 != 0;
+        if timer_control {
+            self.timer.stop();
+        } else {
+            self.timer.start();
+        }
+        self.bank_switching_lock.write(timer_control);
+        if self.bank_switching_lock.locked() {
+            self.prg_rom_banks.set_range(0, 1, 0);
+            return;
+        }
+
+        let outer_bank = self.mmc1.chr0 & Self::OUTER_BANK_MASK;
+
+        let inner_bank = if outer_bank == 0 {
+            self.mmc1.chr0
+        } else {
+            self.mmc1.prg
+        } & Self::INNER_BANK_MASK;
+
+        if self.mmc1.prg_mode && outer_bank != 0 {
+            if self.mmc1.prg_bank_select {
+                self.prg_rom_banks.set(0, (inner_bank | outer_bank).into());
+                self.prg_rom_banks
+                    .set(1, (Self::INNER_BANK_MASK | outer_bank).into());
+            } else {
+                self.prg_rom_banks.set(0, outer_bank.into());
+                self.prg_rom_banks.set(1, (inner_bank | outer_bank).into());
+            }
+        } else {
+            self.prg_rom_banks
+                .set_range(0, 1, ((inner_bank & !0b1) | outer_bank).into()); // ignore low bit
+        }
+    }
+}
+
+impl Map for NesEvent {
+    fn chr_peek(&self, addr: u16, ciram: &crate::ppu::CIRam) -> u8 {
+        match addr {
+            0x0000..=0x1FFF => self.chr[usize::from(addr)],
+            0x2000..=0x3EFF => ciram.peek(addr, self.mirroring()),
+            _ => 0,
+        }
+    }
+
+    fn prg_peek(&self, addr: u16) -> u8 {
+        match addr {
+            0x6000..=0x7FFF if self.mmc1.prg_ram_enabled() => {
+                self.prg_ram[usize::from(addr) & (Self::PRG_RAM_SIZE - 1)]
+            }
+            0x8000..=0xFFFF => self.prg_rom[self.prg_rom_banks.translate(addr)],
+            _ => 0,
+        }
+    }
+
+    fn mirroring(&self) -> crate::prelude::Mirroring {
+        self.mmc1.mirroring
+    }
+
+    fn chr_write(&mut self, addr: u16, val: u8, ciram: &mut crate::ppu::CIRam) {
+        match addr {
+            0x0000..=0x1FFF => self.chr[usize::from(addr)] = val,
+            0x2000..=0x3EFF => ciram.write(addr, val, self.mirroring()),
+            _ => (),
+        }
+    }
+
+    fn prg_write(&mut self, addr: u16, val: u8) {
+        match addr {
+            0x6000..=0x7FFF if self.mmc1.prg_ram_enabled() => {
+                self.prg_ram[usize::from(addr) & (Self::PRG_RAM_SIZE - 1)] = val;
+            }
+            0x8000..=0xFFFF => {
+                let written = self.mmc1.process_shift_register_write(addr, val);
+                if written {
+                    self.update_state();
+                }
+            }
+            _ => (),
+        }
+    }
+
+    fn irq_pending(&self) -> bool {
+        self.timer.irq_pending()
+    }
+}
+
+impl Reset for NesEvent {
+    fn reset(&mut self, kind: ResetKind) {
+        self.mmc1.reset(kind);
+        self.mmc1.chr0 = 0b10000; // Initially, banking is locked, and the timer does not count 
+        self.bank_switching_lock.reset(kind);
+        self.timer.reset(kind);
+        self.update_state();
+    }
+}
+
+impl Clock for NesEvent {
+    fn clock(&mut self) {
+        self.mmc1.clock();
+        self.timer.clock();
+    }
+}
+
+impl Regional for NesEvent {}
+impl Sram for NesEvent {}

--- a/tetanes-core/src/mapper/mmc1.rs
+++ b/tetanes-core/src/mapper/mmc1.rs
@@ -1,0 +1,227 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    common::{Clock, Reset, ResetKind},
+    ppu::Mirroring,
+};
+
+/// MMC1 Revision.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[must_use]
+pub enum Revision {
+    /// MMC1 Revision A
+    A,
+    /// MMC1 Revisions B & C
+    #[default]
+    BC,
+}
+
+/// The `MMC1` chip.
+#[derive(Clone, Serialize, Deserialize)]
+#[must_use]
+pub struct Mmc1 {
+    pub revision: Revision,
+    pub write_just_occurred: u8,
+    pub write_buffer: u8,       // $8000-$FFFF - 5 bit shift register
+    pub shift_count: u8,        // How many times write_buffer has shifted
+    pub prg_ram_disabled: bool, // $E000-$FFFF bit 4
+    pub chr_mode: bool,         // $8000-$9FFF bit 4
+    pub prg_mode: bool,         // $8000-$9FFF bit 3
+    pub prg_bank_select: bool,  // $8000-$9FFF bit 2
+    pub mirroring: Mirroring,   // $8000-$9FFF bits 0-1
+    pub last_chr_reg: u16,      // Last chr register written to
+    pub chr0: u8,               // $A000-$BFFF
+    pub chr1: u8,               // $C000-$DFFF
+    pub prg: u8,                // $E000-$FFFF bits 0-3
+}
+
+impl Mmc1 {
+    const SHIFT_REG_RESET: u8 = 0x80; // Reset shift register when bit 7 is set
+    const MIRRORING_MASK: u8 = 0x03; // 0b00011
+    const SLOT_SELECT_MASK: u8 = 0x04; // 0b00100
+    const PRG_MODE_MASK: u8 = 0x08; // 0b01000
+    const CHR_MODE_MASK: u8 = 0x10; // 0b10000
+
+    const CHR_BANK_MASK: u8 = 0x1F;
+    const PRG_BANK_MASK: u8 = 0x0F;
+    const PRG_RAM_DISABLED: u8 = 0x10; // 0b10000
+
+    pub fn new(revision: Revision) -> Self {
+        Self {
+            revision,
+            write_just_occurred: 0x00,
+            write_buffer: 0x00,
+            shift_count: 0,
+            prg_ram_disabled: revision == Revision::A,
+            chr_mode: false,
+            prg_mode: true,
+            prg_bank_select: true,
+            mirroring: Mirroring::SingleScreenA,
+            last_chr_reg: 0xA000,
+            chr0: 0x00,
+            chr1: 0x00,
+            prg: 0x00,
+        }
+    }
+
+    /// Reset the shift register write buffer.
+    const fn reset_buffer(&mut self) {
+        self.shift_count = 0;
+        self.write_buffer = 0;
+    }
+
+    pub const fn process_shift_register_write(&mut self, addr: u16, val: u8) -> bool {
+        // Writes data into a shift register. At every 5th
+        // write, the data is written out to the `SxROM` registers
+        // and the shift register is cleared
+        //
+        // Load Register $8000-$FFFF
+        // 7654 3210
+        // Rxxx xxxD
+        // |       +- Data bit to be shifted into shift register, LSB first
+        // +--------- 1: Reset shift register and write control with (Control OR $0C),
+        //               locking PRG-ROM at $C000-$FFFF to the last bank.
+        //
+        // Control $8000-$9FFF
+        // 43210
+        // CPPMM
+        // |||++- Mirroring (0: one-screen, lower bank; 1: one-screen, upper bank;
+        // |||               2: vertical; 3: horizontal)
+        // |++--- PRG-ROM bank mode (0, 1: switch 32K at $8000, ignoring low bit of bank number;
+        // |                         2: fix first bank at $8000 and switch 16K bank at $C000;
+        // |                         3: fix last bank at $C000 and switch 16K bank at $8000)
+        // +----- CHR-ROM bank mode (0: switch 8K at a time; 1: switch two separate 4K banks)
+        //
+        // CHR bank 0 $A000-$BFFF
+        // 42310
+        // CCCCC
+        // +++++- Select 4K or 8K CHR bank at PPU $0000 (low bit ignored in 8K mode)
+        //
+        // CHR bank 1 $C000-$DFFF
+        // 43210
+        // CCCCC
+        // +++++- Select 4K CHR bank at PPU $1000 (ignored in 8K mode)
+        //
+        // For Mapper001
+        // $A000 and $C000:
+        // 43210
+        // EDCBA
+        // |||||
+        // ||||+- CHR A12
+        // |||+-- CHR A13, if extant (CHR >= 16k)
+        // ||+--- CHR A14, if extant; and PRG-RAM A14, if extant (PRG-RAM = 32k)
+        // |+---- CHR A15, if extant; and PRG-RAM A13, if extant (PRG-RAM >= 16k)
+        // +----- CHR A16, if extant; and PRG-ROM A18, if extant (PRG-ROM = 512k)
+        //
+        // PRG bank $E000-$FFFF
+        // 43210
+        // RPPPP
+        // |++++- Select 16K PRG-ROM bank (low bit ignored in 32K mode)
+        // +----- PRG-RAM chip enable (0: enabled; 1: disabled; ignored on MMC1A)
+
+        if self.write_just_occurred > 0 {
+            return false;
+        }
+        self.write_just_occurred = 2;
+
+        if val & Self::SHIFT_REG_RESET == Self::SHIFT_REG_RESET {
+            self.reset_buffer();
+            self.prg_mode = true;
+            self.prg_bank_select = true;
+            return true;
+        } else {
+            // Move shift register and write lowest bit of val
+            self.write_buffer >>= 1;
+            self.write_buffer |= (val << 4) & 0x10;
+
+            self.shift_count += 1;
+            // Check if its time to write
+            if self.shift_count == 5 {
+                self.process_register_write(addr, self.write_buffer);
+                self.reset_buffer();
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Process register write, extracting registers into flags.
+    const fn process_register_write(&mut self, addr: u16, val: u8) {
+        match addr & 0xE000 {
+            0x8000 => {
+                self.mirroring = match val & Self::MIRRORING_MASK {
+                    0b00 => Mirroring::SingleScreenA,
+                    0b01 => Mirroring::SingleScreenB,
+                    0b10 => Mirroring::Vertical,
+                    _ => Mirroring::Horizontal,
+                };
+                self.prg_bank_select = (val & Self::SLOT_SELECT_MASK) != 0;
+                self.prg_mode = (val & Self::PRG_MODE_MASK) != 0;
+                self.chr_mode = (val & Self::CHR_MODE_MASK) != 0;
+            }
+            0xA000 => {
+                self.last_chr_reg = addr;
+                self.chr0 = val & Self::CHR_BANK_MASK;
+            }
+            0xC000 => {
+                self.last_chr_reg = addr;
+                self.chr1 = val & Self::CHR_BANK_MASK;
+            }
+            0xE000 => {
+                self.prg = val & Self::PRG_BANK_MASK;
+                self.prg_ram_disabled = (val & Self::PRG_RAM_DISABLED) != 0;
+            }
+            _ => (),
+        }
+    }
+
+    #[inline(always)]
+    pub fn prg_ram_enabled(&self) -> bool {
+        self.revision == Revision::A || !self.prg_ram_disabled
+    }
+
+    pub const fn set_revision(&mut self, revision: Revision) {
+        self.revision = revision;
+    }
+}
+
+impl Reset for Mmc1 {
+    fn reset(&mut self, kind: ResetKind) {
+        self.reset_buffer();
+        self.prg_mode = true;
+        self.prg_bank_select = true;
+        if kind == ResetKind::Hard {
+            self.write_just_occurred = 0;
+            self.prg_ram_disabled = false;
+        }
+    }
+}
+
+impl Clock for Mmc1 {
+    fn clock(&mut self) {
+        if self.write_just_occurred > 0 {
+            self.write_just_occurred -= 1;
+        }
+    }
+}
+
+impl std::fmt::Debug for Mmc1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Mmc1")
+            .field("revision", &self.revision)
+            .field("write_just_occurred", &self.write_just_occurred)
+            .field("write_buffer", &format_args!("0b{:08b}", self.write_buffer))
+            .field("shift_count", &self.shift_count)
+            .field("prg_ram_disabled", &self.prg_ram_disabled)
+            .field("chr_mode", &self.chr_mode)
+            .field("prg_mode", &self.prg_mode)
+            .field("prg_bank_select", &self.prg_bank_select)
+            .field("mirroring", &self.mirroring)
+            .field("last_chr_reg", &self.last_chr_reg)
+            .field("chr0", &format_args!("${:02X}", self.chr0))
+            .field("chr1", &format_args!("${:02X}", self.chr1))
+            .field("prg", &format_args!("${:02X}", self.prg))
+            .field("prg_ram_enabled", &self.prg_ram_enabled())
+            .finish()
+    }
+}


### PR DESCRIPTION
Adds support for mapper 105, NES-EVENT, an MMC1-based multicart board used in a single official game, Nintendo World Championships 1990.

I cannot vouch for 100% accuracy, particularly in relation to the startup/reset state, but NWC1990 seems empirically playable, and I was also able to play back https://tasvideos.org/6742M just fine via a custom wrapper around `tetanes-core`.

This pull request also includes a series of refactoring changes to split out MMC1 logic from SxROM such that it could then be reused for NES-EVENT. I am not sure what the state of the art tests for mapper 1 are, and I think the current test suite doesn't test SxROM functionality, but I've at least verified that the mapper 1 Holy Mapperel tests pass.