### PR TITLE
fix(docs) use `doc_cfg` instea of renamed `doc_auto_cfg`

### DIFF
--- a/tetanes-core/src/lib.rs
+++ b/tetanes-core/src/lib.rs
@@ -3,7 +3,7 @@
     html_favicon_url = "https://github.com/lukexor/tetanes/blob/main/assets/linux/icon.png?raw=true",
     html_logo_url = "https://github.com/lukexor/tetanes/blob/main/assets/linux/icon.png?raw=true"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod action;
 pub mod apu;

--- a/tetanes/src/lib.rs
+++ b/tetanes/src/lib.rs
@@ -3,7 +3,7 @@
     html_favicon_url = "https://github.com/lukexor/tetanes/blob/main/assets/linux/icon.png?raw=true",
     html_logo_url = "https://github.com/lukexor/tetanes/blob/main/assets/linux/icon.png?raw=true"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod error;
 pub mod logging;


### PR DESCRIPTION
Rust 1.92 removed `feature(doc_auto_cfg)`, causing docs.rs build to fail with E0557.

Let's update the conditional feature flag to `doc_cfg` to restore documentation build.