### PR TITLE
chore: release v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -478,9 +478,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bincode"
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -1971,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
@@ -2128,9 +2128,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -3936,14 +3936,14 @@ dependencies = [
 
 [[package]]
 name = "tetanes"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "accesskit",
  "accesskit_winit",
  "ahash",
  "anyhow",
  "arboard",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bincode",
  "bytemuck",
  "cfg-if",
@@ -3989,10 +3989,10 @@ dependencies = [
 
 [[package]]
 name = "tetanes-core"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
- "base64 0.23.0",
+ "base64 0.23.1",
  "bincode",
  "bitflags 2.13.1",
  "cfg-if",
@@ -4011,14 +4011,14 @@ dependencies = [
 
 [[package]]
 name = "tetanes-libretro"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "tetanes-core",
 ]
 
 [[package]]
 name = "tetanes-utils"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4087,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",
@@ -4716,9 +4716,9 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.2"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef62a3d5f7b2411119a11b6f62570dbff91d7105e011a20fb83fbf8f5761c40f"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
  "jni",
  "log",
@@ -5379,9 +5379,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "yoke"
@@ -5505,18 +5505,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5599,9 +5599,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 members = ["tetanes", "tetanes-core", "tetanes-libretro", "tetanes-utils"]
 
 [workspace.package]
-version = "0.14.2"
+version = "0.15.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 authors = ["Luke Petherbridge <me@lukeworks.tech>"]
@@ -48,7 +48,7 @@ egui = { version = "0.35.0", default-features = false }
 egui_extras = { version = "0.35", default-features = false }
 image = { version = "0.25", default-features = false, features = ["png"] }
 serde = { version = "1.0", features = ["derive"] }
-tetanes-core = { version = "0.14", path = "tetanes-core" }
+tetanes-core = { version = "0.15", path = "tetanes-core" }
 thiserror = "2.0"
 tracing = { version = "0.1", default-features = false, features = [
   "std",

--- a/tetanes-core/CHANGELOG.md
+++ b/tetanes-core/CHANGELOG.md
@@ -7,6 +7,204 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0](https://github.com/lukexor/tetanes/compare/0.14.2..0.15.0) - 2026-08-06
+
+### ⛰️  Features
+
+- *(apu)* Add band-limited step synthesis - ([a6f0df0](https://github.com/lukexor/tetanes/commit/a6f0df0edbcb4eb8f905bbe75e38820412f6a5fa))
+- *(bench)* TETANES_BENCH_FILTER selects the output filter - ([36b2646](https://github.com/lukexor/tetanes/commit/36b26463ac6bdec04f4f57f9879b4624674fd345))
+- *(core)* [**breaking**] One patch table for every kind of cheat - ([5214d3b](https://github.com/lukexor/tetanes/commit/5214d3bf2a7f54a8320ada1d4545814cf07321a8))
+**BREAKING**: `Bus::genie_codes` is replaced by `Bus::patches`, and a console state no longer carries cheats.
+- *(core)* [**breaking**] Default to a 48 kHz sample rate - ([7f2071a](https://github.com/lukexor/tetanes/commit/7f2071a3e875ee1c750d2ffe77e40e48b4b459e6))
+**BREAKING**: `Apu::DEFAULT_SAMPLE_RATE` is 48 kHz, so a deck that does not call `set_sample_rate` produces different samples than before.
+- *(core)* Serialize console state into a caller's buffer - ([52e00af](https://github.com/lukexor/tetanes/commit/52e00af6d7876922af707cace6060b7986248c4b))
+- *(core)* Add page-based cartridge memory translation - ([398793e](https://github.com/lukexor/tetanes/commit/398793e54fd22944d0a0403eb45cff05bf617bac))
+- *(libretro)* Expose the console's memory to the frontend - ([1538183](https://github.com/lukexor/tetanes/commit/1538183b92974582527501009d18689f759b07f3))
+- *(mapper)* Add Taito TC0190/TC0350 and TC0690 (Mappers 33, 48) - ([b127fe6](https://github.com/lukexor/tetanes/commit/b127fe62b37edcfd95ed9ed23cbb7822bb60779b))
+- *(mapper)* Add VRC2/VRC4 (Mappers 021, 022, 023, 025) - ([6cde160](https://github.com/lukexor/tetanes/commit/6cde1600af04cbe17251ab58ae4be29190b660e1))
+- *(mapper)* Report board registers for a debugger pane - ([571d870](https://github.com/lukexor/tetanes/commit/571d87051c513549ece940eb19fee7f046722ab3))
+- *(mapper)* Implement MMC5's vertical split screen - ([bdfd9e8](https://github.com/lukexor/tetanes/commit/bdfd9e8f2235dcbef55589660babc852022389cd))
+- *(mapper)* [**breaking**] Serve MMC5 from page tables - ([1299ca9](https://github.com/lukexor/tetanes/commit/1299ca91f836945f7f28f1490c84e89762345411))
+**BREAKING**: `Exrom::read_ex_ram`, `write_ex_ram`, `rom_select`, `set_prg_bank_range`, `update_prg_banks` and `update_chr_banks` are gone; MMC5 serves its memory from page tables and republishes banking through `Map::update_banks`. `Cart::chr_size` goes with the last board that needed it.
+- *(mapper)* Add a PPU read hook for boards that synthesise CHR reads - ([1a0a68e](https://github.com/lukexor/tetanes/commit/1a0a68e648a3a4942af06c963d1fbd68399cab5c))
+- *(mapper)* Serve FK23C from page tables - ([98fb652](https://github.com/lukexor/tetanes/commit/98fb6523fc6da2c56209e2219b03ad4625d9c7d4))
+- *(mapper)* Serve BandaiFCG from page tables - ([53db1d7](https://github.com/lukexor/tetanes/commit/53db1d78f6a5e0cb5efef722fe0680d03c942135))
+- *(mapper)* Serve Namco163 from page tables - ([7e121ec](https://github.com/lukexor/tetanes/commit/7e121eceb453718b69f8c179d43bd9f6791981e6))
+- *(mapper)* Serve MMC2 and MMC4 from page tables - ([91aa8c5](https://github.com/lukexor/tetanes/commit/91aa8c5322ffc760e00e2dbe67edab0b8e358d40))
+- *(mapper)* Serve NES-EVENT from page tables - ([bde36ff](https://github.com/lukexor/tetanes/commit/bde36ff887ecc64c9a39911fbf3df6f358438568))
+- *(mapper)* Serve VRC6 from page tables - ([621acb0](https://github.com/lukexor/tetanes/commit/621acb0a492861d5f9253ec9e5dabd45f2d3db3e))
+- *(mapper)* Serve FME7 and Jaleco SS88006 from page tables - ([cd60771](https://github.com/lukexor/tetanes/commit/cd607715a0d39cbdfc3e891b9363de6b4a11978b))
+- *(mapper)* [**breaking**] Serve MMC3 from page tables - ([c3af9a0](https://github.com/lukexor/tetanes/commit/c3af9a065f1dad9f4b2d662b09dbc86c421ef2de))
+**BREAKING**: `Mmc3::set_chr_banks` is gone, along with the board's own `update_prg_banks`/`update_chr_banks`. MMC3 republishes its banking through `Map::update_banks` from the register file, and four-screen carts allocate 4K of CIRAM rather than a separate `ex_ram` buffer.
+- *(mapper)* Serve MMC1 from page tables - ([00a62b4](https://github.com/lukexor/tetanes/commit/00a62b461e034e7a2001e1816e070eee06ad1ae7))
+- *(mapper)* Serve tier 3a bank-switchers from page tables - ([9b63b40](https://github.com/lukexor/tetanes/commit/9b63b40efd92f8a48920b639107b3e306a2df0f2))
+- *(mapper)* Serve NROM from page tables - ([9e7e71e](https://github.com/lukexor/tetanes/commit/9e7e71e08c1ad1dac3b77d680e3eaba65e51cdf8))
+
+
+### 🐛 Bug Fixes
+
+- *(apu)* Size the BLEP buffer from the rate it is tuned to - ([8e5179b](https://github.com/lukexor/tetanes/commit/8e5179b7c2ec1c73a9a712c74f879b44731bb2e7))
+- *(audio)* Pace on a deadline and hold the buffer with rate control - ([8d27d27](https://github.com/lukexor/tetanes/commit/8d27d27bcb8572e6da5e9c2f46de52c045a6c437))
+- *(cart)* Load Dream Master as mapper 210 - ([05fdef3](https://github.com/lukexor/tetanes/commit/05fdef3e82b8a48bf907092e662d151df26c3c55))
+- *(cart)* Load Famicom Jump II as mapper 153 - ([ea94174](https://github.com/lukexor/tetanes/commit/ea94174b82616a690c51fa374deda73178d2b311))
+- *(cart)* Read the NES 2.0 ram size bytes as two nibbles - ([2110e9f](https://github.com/lukexor/tetanes/commit/2110e9f90093a2f9328271db8eed733f05c9c4db))
+- *(cart)* Correct Top Rider's mapper and stop the game db self-referencing - ([fa6098f](https://github.com/lukexor/tetanes/commit/fa6098fcbde1b2ef7b0de558d16decc6ece88a95))
+- *(control-deck)* Stop a restored state reverting the player's settings - ([e3b64a8](https://github.com/lukexor/tetanes/commit/e3b64a8295a37f0f2b673b1749d80014a73bcbf1))
+- *(control-deck)* Refresh the frame when the console moves without a clock - ([ea4575f](https://github.com/lukexor/tetanes/commit/ea4575f19360afd74aaf0aede47b369b3f087437))
+- *(core)* Power-cycle cart RAM on a hard reset - ([9baa46e](https://github.com/lukexor/tetanes/commit/9baa46e4277bf1ca251183215f35c64582ccbada))
+- *(core)* [**breaking**] Match a save state to its cart by ROM CRC, not by size - ([52632c2](https://github.com/lukexor/tetanes/commit/52632c233c9ee3d24407129e7aa03ec415218f4d))
+**BREAKING**: save states record the cart's ROM CRC32; states written by earlier builds no longer load.
+- *(core)* [**breaking**] Hand out one nes frame per clock_frame call - ([7cca0af](https://github.com/lukexor/tetanes/commit/7cca0af3c7cc03a83bdf6ae6329a6b17c8a8c8b3))
+**BREAKING**: `ControlDeck::clock_frame` returns `Result<Clocked>` rather than `Result<()>` and clocks at most one NES frame per call; drive it with `while deck.clock_frame()? == Clocked::Continue {}` to clock a whole display frame as before.
+- *(core)* Keep the player's settings out of restored states - ([8afede0](https://github.com/lukexor/tetanes/commit/8afede031ebe80fb198d59d41ca566749466435a))
+- *(core)* Keep load_bytes on the save version - ([be52911](https://github.com/lukexor/tetanes/commit/be52911a24cecca50c57c857fb668c8ece83408d))
+- *(core)* Wrap page offsets within their region - ([fa7f637](https://github.com/lukexor/tetanes/commit/fa7f637a3f1620102fed38c744c46e799614dc0e))
+- *(fs)* Report header versions as text - ([7e2795b](https://github.com/lukexor/tetanes/commit/7e2795b496a68cb355fcabc1dc7a4d12f47d86e1))
+- *(mapper)* Stop FK23C write-enabling its unmapped WRAM windows - ([e070fde](https://github.com/lukexor/tetanes/commit/e070fded8c58c43ac01bbc7bc54b58388d8b2360))
+- *(mapper)* Decode VRC2's mirroring register at all four indices - ([0f5c29f](https://github.com/lukexor/tetanes/commit/0f5c29f29149e0c0ec512c29971f7bdeaef1fc13))
+- *(mapper)* Decode FME-7's R:8 select bit - ([878b82e](https://github.com/lukexor/tetanes/commit/878b82eef94ccbfeb2735a88b8d698397480e264))
+- *(mapper)* Apply mapper 210's mirroring - ([138f134](https://github.com/lukexor/tetanes/commit/138f13477ab795d9a15b05e914a48ca0aa86bf88))
+- *(mapper)* Correct MMC5's split prefetch scroll and $5204 readback - ([7b7b190](https://github.com/lukexor/tetanes/commit/7b7b19017ce352b03eac8155c72945b71f4cfd8e))
+- *(mapper)* Let mapper 153 read its own PRG-RAM - ([d53b2db](https://github.com/lukexor/tetanes/commit/d53b2db570740b87e32da4f8514bb85ec5008928))
+- *(mapper)* [**breaking**] Tag serialized boards by a stable id, not declaration order - ([8440bb3](https://github.com/lukexor/tetanes/commit/8440bb3335f352a5fc14384b97ff5838fba82702))
+**BREAKING**: `Mapper::Fk23C` is no longer boxed, and a mapper number no board serves is now `mapper::Error::Unimplemented` rather than a silent `Mapper::none()` that read as open bus. Tools that survey ROMs rather than run them should use `Cart::from_rom_unmapped`/`Cart::from_path_unmapped`. The on-disk format is byte-for-byte unchanged by this commit.
+- *(mapper)* Honour MMC5's sprite-size rule for CHR bank sets - ([4218c4d](https://github.com/lukexor/tetanes/commit/4218c4d5304a219336904e313306366251a36909))
+- *(mapper)* Ignore FK23C's CHR-RAM select when the cart has no CHR-RAM - ([69e754f](https://github.com/lukexor/tetanes/commit/69e754f16e3b003af8e56014e1becafdaef8758b))
+- *(mapper)* Apply Namco163 nametable select on every board variant - ([0bf93f4](https://github.com/lukexor/tetanes/commit/0bf93f4fa182afab2aecc5d1a01a567d0ebdb8cc))
+- *(mapper)* Make VRC6 helpers const - ([79d3766](https://github.com/lukexor/tetanes/commit/79d376696b38010be8b25e18d6c047d4aa64cb27))
+- *(mapper)* Restore nametable mirroring in sync, and unpin the game db - ([c47a60c](https://github.com/lukexor/tetanes/commit/c47a60cfbe10b4aad2ffb2218344ad7feb1a82f9))
+- *(mapper)* Rebuild page tables when a save state is loaded - ([9de76c8](https://github.com/lukexor/tetanes/commit/9de76c81b9bd34d385e5a7cf4628fb50242c8987))
+- *(ppu)* Read the dummy NT bytes on dots 337 and 339 only - ([e38ecb6](https://github.com/lukexor/tetanes/commit/e38ecb6f8ca484cc87ec8e02305ad7b26a6cda90))
+- *(ppu)* Stop rotating the palette latches on the dummy NT fetches - ([bd2a8db](https://github.com/lukexor/tetanes/commit/bd2a8dba42e237646bb5f03ef4c3ffbc0e225e13))
+- *(ppu)* [**breaking**] Forward the region to the mapper, and box SunsoftFme7 - ([f421867](https://github.com/lukexor/tetanes/commit/f4218677ee52d56004a888db6310cb2673b42fd4))
+**BREAKING**: `Mapper::SunsoftFme7` is now boxed. The `boards!` stable ids become each board's primary mapper number, which changes the tag written into save states - riding the same undeployed SAVE_VERSION 2 bump as the rest of this release.
+- *(sram)* Back up a save that cannot be read - ([5b2b671](https://github.com/lukexor/tetanes/commit/5b2b671a64fd627c215373e148a2ed712a1b74c1))
+- *(sram)* Version battery saves independently of save states - ([7f23d4b](https://github.com/lukexor/tetanes/commit/7f23d4b094b1e312cabe50e6b50fc9ea1b2551f1))
+- *(test)* Stop UPDATE_SNAPSHOT clobbering parallel snapshot writes - ([fcb1e0d](https://github.com/lukexor/tetanes/commit/fcb1e0dd54a35c49ed5c6bbeca30021ffb0a2d6d))
+
+- Drop Game Genie codes when the cart is swapped - ([3ae10ff](https://github.com/lukexor/tetanes/commit/3ae10ff924781ca3d4dcb70704ae2fa3bcd49244))
+
+### 🚜 Refactor
+
+- *(core)* [**breaking**] Give a cart's battery one contiguous slice - ([6d3586b](https://github.com/lukexor/tetanes/commit/6d3586b350bdfe34880e4397ca250a26295b07a8))
+**BREAKING**: `Map::save_sram`/`load_sram` are replaced by `sync_battery`/`restore_battery`, `MemoryLayout` gains `battery_ext`, and `ControlDeck::sram`/`save_sram` take `&mut self`.
+- *(core)* [**breaking**] Take readers and writers, not paths - ([04bc7ae](https://github.com/lukexor/tetanes/commit/04bc7aec2f2ad5a72d35c795b8144890dbdedd37))
+**BREAKING**: `fs` and `ControlDeck` save/load now take `Read`/`Write`, the path-taking forms are `*_path`, `fs::load_bytes` is gone since `&[u8]` is already a reader, and `Config::data_dir` is replaced by `Config::sram_dir: Option<PathBuf>`.
+- *(core)* [**breaking**] Drop the accessors that only return a public field - ([4c8891d](https://github.com/lukexor/tetanes/commit/4c8891dbaa034a99aab83a4d2ec5a98abd9cfd85))
+**BREAKING**: Cart::region, Cart::ram_state, Bus::region, Ppu::region, Apu::region, Dmc::region, Noise::region, Joypad::index, Zapper::x, Zapper::y and Mmc3::irq_pending are removed; read the field of the same name.
+- *(core)* Put run-ahead's rewind through the restore funnel - ([4748ffe](https://github.com/lukexor/tetanes/commit/4748ffedb447bf36bb84fde86c8a206166f48894))
+- *(core)* [**breaking**] Name the debugger accessors for the one debugger there is - ([1902979](https://github.com/lukexor/tetanes/commit/19029792c850326caa511cca5f0674ce23567ff5))
+**BREAKING**: `ControlDeck::add_debugger`/`remove_debugger` are now `set_debugger`/`clear_debugger`, and the latter takes no argument.
+- *(core)* [**breaking**] Make memory::Buffer crate-internal - ([9ef4227](https://github.com/lukexor/tetanes/commit/9ef42277d9571d5b65a155f554994ef503a0975d))
+**BREAKING**: `memory::Buffer` and its unused constructors are no longer public.
+- *(core)* Drop the unused BandLimited accessors - ([9875f48](https://github.com/lukexor/tetanes/commit/9875f481e579daaf95090171b32669abaad8efef))
+- *(core)* Move the mapper and debugger bus methods out of ppu.rs - ([b13767e](https://github.com/lukexor/tetanes/commit/b13767e550c839b69a33cd3e070815cfb7ec0c07))
+- *(core)* [**breaking**] Consolidate the Bus surface after flattening - ([7afe6cc](https://github.com/lukexor/tetanes/commit/7afe6cc106756d68dd619c703994d3ccb04c07ea))
+**BREAKING**: `Input::read`/`Input::peek` are `read_port`/`peek_port` and no longer take a `&Ppu`; `Bus::input_read`/`input_peek` are what read $4016/$4017. `Bus::cpu_bus_read`/`cpu_bus_write`/`cpu_bus_peek` and `ppu_bus_read`/`ppu_bus_write` are now crate-internal; use `Bus::peek`, `Bus::ppu_bus_peek`, `Bus::chr_peek` or `Bus::copy_ppu_bus` to observe.
+- *(core)* [**breaking**] Flatten ownership so Bus holds the console - ([c34e8b8](https://github.com/lukexor/tetanes/commit/c34e8b883817bb2d882ec4dd26600d0dcabc45de))
+**BREAKING**: `ControlDeck::cpu()` returns registers only; the console is `ControlDeck::bus()`, and save states, rewind and replay are now `Bus` rather than `Cpu`. `ControlDeck::load_cpu` is `load_bus`. `Mapper` and `Memory` moved from `Ppu` to `Bus`, as did the debugger. `PpuDebugger` is `Debugger` and its callback takes `&Bus`. `Ppu::load_nametables`/`load_pattern_tables`/`load_oam` take the CHR window to read from. The `memory::Read` and `memory::Write` traits are removed in favor of inherent methods. Save states from earlier builds will not load.
+- *(core)* [**breaking**] Make video::Frame a fixed-size buffer - ([b79a2fe](https://github.com/lukexor/tetanes/commit/b79a2fefc16376587eb8c2f044f3583bcd43789b))
+**BREAKING**: `video::Frame` no longer derefs to `Vec<u8>`. Callers using it as a `Vec` should use `as_slice`, `as_array`, or indexing; callers that resized it have no replacement, as the size is now part of the type.
+- *(core)* [**breaking**] Collapse the clocking API and clean up public surface - ([2b4fd1e](https://github.com/lukexor/tetanes/commit/2b4fd1eb4e4b102c9342f4d42a75d6eff077e1e7))
+**BREAKING**: MSRV is now 1.88; 1.85 could not build the crate at all. `Map::sync` is `Map::update_banks`, `Ppu::sync_mapper` is `Ppu::rebuild_mapper_state`, and MMC5's colliding `update_chr_banks` is `select_chr_set`. Frame buffers are fixed-size: `Ppu::frame_buffer` and `ControlDeck::frame_buffer_raw` return `&[u16; ppu::size::FRAME]`, `ControlDeck::frame_buffer` returns `&[u8; Frame::SIZE]`, and `frame_buffer_into` takes `&mut [u8; Frame::SIZE]`. `ControlDeck::apu_mut` returns `&mut Apu`, `joypad` takes `&self`, and `wram` returns `&[u8; bus::size::WRAM]`. Clocking clears the previous call's audio samples instead of accumulating; opt out with `Config::clear_audio_on_clock = false`. The five older `clock_*` entry points are deprecated shims rather than removals.
+- *(core)* [**breaking**] Delete the convention-only traits from common.rs - ([61cedf4](https://github.com/lukexor/tetanes/commit/61cedf42a12cfc94537d523fb21d63e40ecba8ee))
+**BREAKING**: the `Clock`, `Reset`, `Regional`, `Sample` and `Sram` traits are gone, and the prelude drops them. `clock`, `reset`, `region`, `set_region`, `output`, `save` and `load` are inherent methods on each component and forward exactly as before, so a call like `deck.cpu_mut().clock()` is unchanged - only the trait import goes away.
+- *(core)* [**breaking**] Delete the four single-purpose traits - ([9e9bee0](https://github.com/lukexor/tetanes/commit/9e9bee0bf45f8f2cdd21eca976d89def65fec105))
+**BREAKING**: the `PpuAddr`, `InputRegisters`, `TimerCycle` and `Consume` traits are gone. `PpuAddr` becomes the free functions `ppu::is_attr` and `ppu::is_palette`; the rest become inherent methods on the types that had the impls.
+- *(core)* [**breaking**] Delete the pre-page-table memory path - ([9ca8ae6](https://github.com/lukexor/tetanes/commit/9ca8ae64e1c69b267a14621bb0cecb6a1a1ad85a))
+**BREAKING**: `mapper::Banks`, `mapper::BankAccess`, `ppu::CIRam` and the `mem` module are gone. `mem::Memory<D>` is now `memory::Buffer<D>`, and `memory::Memory` is the page-table address space. The `Cart::prg_rom` and `Cart::chr_rom` fields become the `Cart::memory` arena, with `prg_rom()` and `chr_rom()` accessors returning the unpadded bytes. `Ppu::ciram` is gone - nametables are page entries. `Map`'s read hooks lose their `_hook` suffix: `prg_read`, `prg_peek`, `chr_read`, `chr_peek`.
+- *(mapper)* Drop unused VRC6 nametable setters and MMC3 chr_window - ([1354e7a](https://github.com/lukexor/tetanes/commit/1354e7a3439a7219a9d05fcb725e993da680289f))
+- *(mapper)* Match the documented polarity of mapper 071's mirroring bit - ([421acec](https://github.com/lukexor/tetanes/commit/421acec6f78d01c1696ec56eed14e686dd821b01))
+- *(mapper)* Generate the per-board plumbing from one boards! table - ([c872dd9](https://github.com/lukexor/tetanes/commit/c872dd96e58841e07f0be91ea7c07e15add9752e))
+- *(mapper)* [**breaking**] Give Map every method a board needs, drop the supertraits - ([7a6439a](https://github.com/lukexor/tetanes/commit/7a6439a9968a3702b607e46ff3c2b4d14d8838d1))
+**BREAKING**: `Map` no longer requires `Clock + Regional + Reset + Sram`. `clock`, `reset`, `region` and `set_region` are defaulted methods on `Map` itself, and `impl Map for Mapper` becomes inherent methods on `Mapper`, so `Map` no longer needs importing to call them.
+- *(mapper)* [**breaking**] Unify per-board dispatch flags into MapperOps - ([8abfaee](https://github.com/lukexor/tetanes/commit/8abfaee32986e65a33873b5d775835b94bd27ac7))
+**BREAKING**: `Map::watches_ppu_bus`, `Map::serves_prg_reads` and `Map::serves_chr_reads` are replaced by a single `Map::mapper_ops` returning `MapperOps` bitflags, which also declares `CLOCKED`, `IRQ`, `AUDIO` and `DMA`. A board that does not declare a hook no longer has it called.
+- *(ppu)* Derive fine Y from v instead of caching it - ([c44bca0](https://github.com/lukexor/tetanes/commit/c44bca0954ab346511f811232ad8a3fb188f518f))
+- *(ppu)* [**breaking**] Hold the PPU registers as fields, not structs - ([145a954](https://github.com/lukexor/tetanes/commit/145a95453b8111839df58840df0ce0529385ea09))
+**BREAKING**: `ppu::ctrl::Ctrl`, `ppu::mask::Mask` and `ppu::status::Status` are gone; read the `ctrl_*`, `mask_*` and `status_*` fields on `Ppu` instead.
+
+
+### 📚 Documentation
+
+- *(bench)* Rewrite the benchmark README around running it - ([84357fc](https://github.com/lukexor/tetanes/commit/84357fc5acfa1e252c362cb72fa8a20f09cb2d6a))
+- *(bench)* Record Raspberry Pi 5 on-target results - ([fae0367](https://github.com/lukexor/tetanes/commit/fae0367be3de371e15839c7eb12bbddfccbdcb2a))
+- *(bench)* Decline the MesenCE sprite-shifter port with reasons - ([89fa791](https://github.com/lukexor/tetanes/commit/89fa7912a2fef619d12194327e120c5ff3d1a58e))
+- *(bench)* Scope the two-layout rule to perf verdicts, record fine_y and dummy-fetch results - ([b2e26d8](https://github.com/lukexor/tetanes/commit/b2e26d8dd1a9aaf7e5382e664c2a948937603808))
+- *(bench)* Record the dispatch-reshape layout draw - ([96ef17a](https://github.com/lukexor/tetanes/commit/96ef17ac67fb22c35ddc39a6e179f21b1b1a8c77))
+- *(bench)* Record the shifter-reload layout result - ([54e6b4d](https://github.com/lukexor/tetanes/commit/54e6b4d02f5c31a3835606a32a7411430103dde4))
+- *(bench)* Measure candidates at two code layouts - ([f8e4282](https://github.com/lukexor/tetanes/commit/f8e4282e1b67c357c204fb993024978aae5ec048))
+- *(bench)* Correct profile shares read from the wrong denominator - ([4166301](https://github.com/lukexor/tetanes/commit/416630137aaa520e1dda59193d9dd2e505180009))
+- *(bench)* Correct the boxing conclusion with FME7 ROMs measured - ([97e5da7](https://github.com/lukexor/tetanes/commit/97e5da7c8541af1ed519ce7718f211b55a5bdf02))
+- *(bench)* Record the trait-diet and boards! table results - ([c07971d](https://github.com/lukexor/tetanes/commit/c07971d5b604d03d3b9eb0a5f332046717b9be23))
+- *(bench)* Record the MapperOps results and correct the catch-up conclusion - ([13cae45](https://github.com/lukexor/tetanes/commit/13cae459c7ec7db8290b85b715245006af2f1e24))
+- *(bench)* Record the PPU results and the catch-up investigation - ([9fe62c0](https://github.com/lukexor/tetanes/commit/9fe62c00be75133b816f164dedb40b46ddf2c5c2))
+- *(bench)* Record the frame times after deleting the old memory path - ([17596d1](https://github.com/lukexor/tetanes/commit/17596d1defc5c10c040cceeac4e7b85e317210a8))
+- *(bench)* Record frame times after the mapper rework - ([3968038](https://github.com/lukexor/tetanes/commit/396803876b50d0a4fd5aa1b05ef9222ed9ff042b))
+- *(core)* Correct the mapper, PPU peek and Bus-state docs - ([dfb4207](https://github.com/lukexor/tetanes/commit/dfb420739d1ec2529023265b4dfc104426bcd35d))
+- *(core)* Correct stale board, filter and audio-profile references - ([fff8802](https://github.com/lukexor/tetanes/commit/fff880262c7cb9cc320fd32881b15861bc05da23))
+- *(core)* Describe the code as it stands, not its history - ([5a5b65b](https://github.com/lukexor/tetanes/commit/5a5b65bddb1a806d113bfa48683f4000a47d9176))
+- *(core)* Turn on missing_docs and say which half is API - ([4511ddf](https://github.com/lukexor/tetanes/commit/4511ddfc0981fa6a2309ec4bf37c05f352a55b75))
+- *(mapper)* Link the save-state rebuild to Bus, not Ppu - ([3e24c14](https://github.com/lukexor/tetanes/commit/3e24c14c8def4e428f44b7312af94bba73a409c9))
+- *(mapper)* Correct what FK23C's $A001 handler relies on - ([5e2a93e](https://github.com/lukexor/tetanes/commit/5e2a93eb6fe417366205318730555ea5e95c2129))
+- *(mapper)* Record that Color Dreams boards have no bus conflicts - ([fceecca](https://github.com/lukexor/tetanes/commit/fceecca4ff9104f2cf374a29fa15c52a5daf4491))
+- *(mapper)* Drop the transitional phrasing from the Map trait - ([ac1725d](https://github.com/lukexor/tetanes/commit/ac1725ddebd4d49e367a5e7dced12cca4b09d223))
+- *(memory)* Say why the region wrap is a divide - ([878c8d0](https://github.com/lukexor/tetanes/commit/878c8d0580677710e2fbcbc7372d20c8050b622c))
+
+- Correct stale facts in CLAUDE.md, the mapper docs and the README table - ([b702137](https://github.com/lukexor/tetanes/commit/b70213730005ffcf5e91b3bc073a1cfe8869ec67))
+- Fix stale references and drop history from the branch's comments - ([97a2850](https://github.com/lukexor/tetanes/commit/97a2850fc67cdd2fdec4a43e16c7519cb1728b7d))
+
+### ⚡ Performance
+
+- *(apu)* [**breaking**] Synthesise the output from channel deltas - ([cb9a45b](https://github.com/lukexor/tetanes/commit/cb9a45b3c091e84a3c613010dfb9dd256cb85a8a))
+**BREAKING**: `Apu::sample_period`, `Apu::sample_counter` and `Apu::mapper_outputs` are gone, along with `apu::filter`'s `Fir`, `windowed_sinc_kernel` and the decimation half of `FilterChain`.
+- *(apu)* Run the channels between waveform steps, not every cycle - ([9b9699c](https://github.com/lukexor/tetanes/commit/9b9699c46de7bfbe319af9a2d75797a90b97d48d))
+- *(apu)* Flush denormals and mix only when the filter chain samples - ([9934043](https://github.com/lukexor/tetanes/commit/99340432488e0ed8ac6fca9b1abb726eb920ffc1))
+- *(apu)* [**breaking**] Run the filter chain at two rates instead of six - ([fa2966e](https://github.com/lukexor/tetanes/commit/fa2966eaf00b605cd2ae58497615936222228853))
+**BREAKING**: `apu::filter::Filter`, `apu::filter::SampledFilter` and `FilterKind::Identity` are removed, and `FilterChain`'s fields are now the named stages rather than a `[SampledFilter; 6]`, which changes the save-state layout - covered by the `SAVE_VERSION` bump already on this branch.
+- *(apu)* Mix from integer channel levels in the MMC5 hot path - ([31186ed](https://github.com/lukexor/tetanes/commit/31186edb5b74ad3e97dcbd0fbfda36b73ef1ff1d))
+- *(apu)* Avoid a libm call in the FIR filter hot loop - ([f91f59e](https://github.com/lukexor/tetanes/commit/f91f59ef780b9e0e258223ba66f604c075384e08))
+- *(core)* Snapshot run-ahead into last frame's console - ([42e9378](https://github.com/lukexor/tetanes/commit/42e9378f06ffe76bc7069f61c502a21c15cab045))
+- *(core)* Snapshot run-ahead with a clone instead of bincode - ([605f917](https://github.com/lukexor/tetanes/commit/605f91721346daf39356d28cbe90bb5f143e6449))
+- *(core)* [**breaking**] Keep the cart's ROM out of save states - ([12156e5](https://github.com/lukexor/tetanes/commit/12156e56b69a12774b37e06ad45772cbf03ed1da))
+**BREAKING**: save states and rewind snapshots no longer carry the cart's ROM, so a state can only be applied to the game it came from. `Cpu::load` and `ControlDeck::load_cpu` are fallible, returning `cpu::StateMismatch` when the state does not belong to the loaded cart.
+- *(core)* Hoist per-pixel invariants in the NTSC filter - ([bf6dd6e](https://github.com/lukexor/tetanes/commit/bf6dd6e97a2d8140fafe0aa8d144f1b3e6eb956f))
+- *(core)* Un-box Ppu::sprites; document why wram/frame buffer stay boxed - ([5fac025](https://github.com/lukexor/tetanes/commit/5fac025c4c53306c1e462bd909d4e79841a0113d))
+- *(core)* Split Ppu::clock's branch chain and flag-gate the debugger - ([8656742](https://github.com/lukexor/tetanes/commit/8656742657df18de24d128bdd4f4bc4ff52734ae))
+- *(mapper)* Re-bank only on writes that change banking - ([f1d6f9a](https://github.com/lukexor/tetanes/commit/f1d6f9a10cd0a76098c6b4f079d29a96600ea4e6))
+- *(mapper)* Only re-map the CHR window MMC2/MMC4's latch changed - ([5b2371a](https://github.com/lukexor/tetanes/commit/5b2371a41fe9877d43bbc9ac39a130d173b8f4b0))
+- *(ppu)* Reload BG shifters only on real tile fetches - ([82ad8af](https://github.com/lukexor/tetanes/commit/82ad8afea77fd7b84de6087864de03c09886bf0a))
+- *(ppu)* Gate the pixel path on a dot threshold, not on mask flags - ([41d8ea5](https://github.com/lukexor/tetanes/commit/41d8ea577b3a551ecf34ea679d5f5bf3ff2a2ee1))
+- *(ppu)* Fold greyscale and emphasis in by the run, not per pixel - ([71b7ff1](https://github.com/lukexor/tetanes/commit/71b7ff106abfcc43d17ae9b5571d57ad7d9d1e13))
+- *(ppu)* Visit only the sprites covering a dot - ([341f832](https://github.com/lukexor/tetanes/commit/341f83208885b819067c07e10867b23e1ae68820))
+- *(video)* [**breaking**] Bake the NTSC palette at build time - ([830b850](https://github.com/lukexor/tetanes/commit/830b850da01eee5c9fd683d030c72a6c833d0ae5))
+**BREAKING**: `video::NTSC_PALETTE` is a `&'static [u8; N]` of red, green, blue triples baked in at build time, not a `OnceLock<Vec<u32>>` packing each color into one `u32`.
+- *(wasm)* Store local-storage payloads as base64, not json arrays - ([abb4488](https://github.com/lukexor/tetanes/commit/abb44881dfc258ede42689ef50517c9cc7b99d0d))
+
+
+### 🧪 Testing
+
+- *(apu)* Assert audio with a coarse profile instead of a sample hash - ([e411661](https://github.com/lukexor/tetanes/commit/e4116615f5ee744c708e05b3e4e5148346bc4127))
+- *(core)* Implement the bus routing tests and drop the two unassertable ROMs - ([dc60b4b](https://github.com/lukexor/tetanes/commit/dc60b4b178e1f7e1f64df16b28a2e0bb3f24065d))
+- *(core)* Assert blargg result codes and report tones instead of ignoring - ([5c2e4e6](https://github.com/lukexor/tetanes/commit/5c2e4e6906979ffed444d4041dc3d4ecb1d2cab9))
+- *(core)* Cover the save-state and SRAM round trips - ([1b8c0d8](https://github.com/lukexor/tetanes/commit/1b8c0d8fde247d81e0ab9d88f7fe67f11c01cd98))
+- *(input)* Assert the zapper through the channel each ROM reports on - ([c483467](https://github.com/lukexor/tetanes/commit/c4834678f9c9ff2feb17a3941e94693f7bcd3d2f))
+- *(mapper)* Make the board tests take the bus's route - ([e260d05](https://github.com/lukexor/tetanes/commit/e260d0584decaffbaf8cf5c87b11329c5bbfb963))
+- *(mapper)* Cover the last 13 boards in the table - ([9a113c3](https://github.com/lukexor/tetanes/commit/9a113c377c771ddada1efeda8a83722eeab44a00))
+- *(mapper)* Cover Jaleco SS88006, Bandai FCG and FK23C - ([a63ddf8](https://github.com/lukexor/tetanes/commit/a63ddf8a9f0a6f144fe0d518472ddbde52d30682))
+- *(mapper)* Cover Namco163, Sunsoft FME7 and MMC1 banking and IRQs - ([32ea7dc](https://github.com/lukexor/tetanes/commit/32ea7dcd1f9473e50851f4ba729cac0a53185581))
+- *(mapper)* Cover the VRC IRQ counter and VRC6, fixing two overflow panics - ([e42aebf](https://github.com/lukexor/tetanes/commit/e42aebfae551ec84095db8d733e8981d14fdfb63))
+- *(ppu)* Assert the field placement the dot loop depends on - ([b063118](https://github.com/lukexor/tetanes/commit/b063118e621843bb1c4ff32d40c6b96c106d337f))
+
+
+### ⚙️ Miscellaneous Tasks
+
+- *(bench)* Allow sweeping a ROM library for load and clock failures - ([a12c552](https://github.com/lukexor/tetanes/commit/a12c552eb4c0578128c72d342989525b2f8491f4))
+- *(bench)* Benchmark a ROM corpus and report variance - ([2d9452e](https://github.com/lukexor/tetanes/commit/2d9452e04c121ecb160fc3e3024f19f64003c409))
+
+- Clear the must_use, const fn and rustdoc warnings - ([5ef3404](https://github.com/lukexor/tetanes/commit/5ef3404c090e5ce564f5a08dd888bc4732060389))
+
+
 ## [0.14.2](https://github.com/lukexor/tetanes/compare/0.14.1..0.14.2) - 2026-06-11
 
 ### ⛰️  Features

--- a/tetanes/CHANGELOG.md
+++ b/tetanes/CHANGELOG.md
@@ -7,6 +7,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0](https://github.com/lukexor/tetanes/compare/0.14.2..0.15.0) - 2026-08-06
+
+### ⛰️  Features
+
+- *(mapper)* Add Taito TC0190/TC0350 and TC0690 (Mappers 33, 48) - ([b127fe6](https://github.com/lukexor/tetanes/commit/b127fe62b37edcfd95ed9ed23cbb7822bb60779b))
+- *(mapper)* Serve tier 3a bank-switchers from page tables - ([9b63b40](https://github.com/lukexor/tetanes/commit/9b63b40efd92f8a48920b639107b3e306a2df0f2))
+
+
+### 🐛 Bug Fixes
+
+- *(audio)* Ramp the output in and out instead of cutting - ([5d25e83](https://github.com/lukexor/tetanes/commit/5d25e8367dd4b33abb6db405229cd512ea139fde))
+- *(audio)* Pace on a deadline and hold the buffer with rate control - ([8d27d27](https://github.com/lukexor/tetanes/commit/8d27d27bcb8572e6da5e9c2f46de52c045a6c437))
+- *(audio)* Prime the output stream before it starts consuming - ([e67a133](https://github.com/lukexor/tetanes/commit/e67a13383ad42293c240219cf564e96e62a86e08))
+- *(core)* [**breaking**] Hand out one nes frame per clock_frame call - ([7cca0af](https://github.com/lukexor/tetanes/commit/7cca0af3c7cc03a83bdf6ae6329a6b17c8a8c8b3))
+**BREAKING**: `ControlDeck::clock_frame` returns `Result<Clocked>` rather than `Result<()>` and clocks at most one NES frame per call; drive it with `while deck.clock_frame()? == Clocked::Continue {}` to clock a whole display frame as before.
+- *(input)* Add enter/shift defaults for start/select - ([68776d2](https://github.com/lukexor/tetanes/commit/68776d2ba8346c44a3ed91e34c1d554f23ae2cbe))
+- *(input)* Stop bindings colliding and buttons sticking - ([d2a6bf7](https://github.com/lukexor/tetanes/commit/d2a6bf7a475fbf0733fd4965a16b716e15998591))
+- *(input)* Fixed shortcuts to be on press instead of on release - ([099462f](https://github.com/lukexor/tetanes/commit/099462f1839a3ccc78de824780b0ccb52672613d))
+- *(input)* Fixed modifier rolling and stuck joypad keys - ([568023c](https://github.com/lukexor/tetanes/commit/568023cae3364a227238497b7d87906d216c1f7f))
+- *(libretro)* Six defects found in review, and the claims that hid them - ([28b97dd](https://github.com/lukexor/tetanes/commit/28b97dd8856f3d81ab25071df9d2d076f740a493))
+- *(ppu-viewer)* Fixed oam tab zoom - ([f150119](https://github.com/lukexor/tetanes/commit/f150119ab51fc413ea6e02b8e2edcd4ae9fc9a31))
+- *(preferences)* Fixed game-genie entry closing when focused in menu - ([2e4b9d6](https://github.com/lukexor/tetanes/commit/2e4b9d64e3222fc0baec1ed32c3dd3bb92dbe5b8))
+- *(renderer)* Sync wgpu surface to window size so menu clicks land - ([a39fede](https://github.com/lukexor/tetanes/commit/a39fede957b41be6e494bbeed5a446289dbc3dc6))
+- *(rewind)* Render every rewound frame below 1x - ([ae4d19b](https://github.com/lukexor/tetanes/commit/ae4d19b0c75e741c9bd9d1a97b36d987ce3c30c8))
+
+- Drop Game Genie codes when the cart is swapped - ([3ae10ff](https://github.com/lukexor/tetanes/commit/3ae10ff924781ca3d4dcb70704ae2fa3bcd49244))
+
+### 🚜 Refactor
+
+- *(core)* [**breaking**] Take readers and writers, not paths - ([04bc7ae](https://github.com/lukexor/tetanes/commit/04bc7aec2f2ad5a72d35c795b8144890dbdedd37))
+**BREAKING**: `fs` and `ControlDeck` save/load now take `Read`/`Write`, the path-taking forms are `*_path`, `fs::load_bytes` is gone since `&[u8]` is already a reader, and `Config::data_dir` is replaced by `Config::sram_dir: Option<PathBuf>`.
+- *(core)* [**breaking**] Flatten ownership so Bus holds the console - ([c34e8b8](https://github.com/lukexor/tetanes/commit/c34e8b883817bb2d882ec4dd26600d0dcabc45de))
+**BREAKING**: `ControlDeck::cpu()` returns registers only; the console is `ControlDeck::bus()`, and save states, rewind and replay are now `Bus` rather than `Cpu`. `ControlDeck::load_cpu` is `load_bus`. `Mapper` and `Memory` moved from `Ppu` to `Bus`, as did the debugger. `PpuDebugger` is `Debugger` and its callback takes `&Bus`. `Ppu::load_nametables`/`load_pattern_tables`/`load_oam` take the CHR window to read from. The `memory::Read` and `memory::Write` traits are removed in favor of inherent methods. Save states from earlier builds will not load.
+- *(core)* [**breaking**] Make video::Frame a fixed-size buffer - ([b79a2fe](https://github.com/lukexor/tetanes/commit/b79a2fefc16376587eb8c2f044f3583bcd43789b))
+**BREAKING**: `video::Frame` no longer derefs to `Vec<u8>`. Callers using it as a `Vec` should use `as_slice`, `as_array`, or indexing; callers that resized it have no replacement, as the size is now part of the type.
+- *(core)* [**breaking**] Collapse the clocking API and clean up public surface - ([2b4fd1e](https://github.com/lukexor/tetanes/commit/2b4fd1eb4e4b102c9342f4d42a75d6eff077e1e7))
+**BREAKING**: MSRV is now 1.88; 1.85 could not build the crate at all. `Map::sync` is `Map::update_banks`, `Ppu::sync_mapper` is `Ppu::rebuild_mapper_state`, and MMC5's colliding `update_chr_banks` is `select_chr_set`. Frame buffers are fixed-size: `Ppu::frame_buffer` and `ControlDeck::frame_buffer_raw` return `&[u16; ppu::size::FRAME]`, `ControlDeck::frame_buffer` returns `&[u8; Frame::SIZE]`, and `frame_buffer_into` takes `&mut [u8; Frame::SIZE]`. `ControlDeck::apu_mut` returns `&mut Apu`, `joypad` takes `&self`, and `wram` returns `&[u8; bus::size::WRAM]`. Clocking clears the previous call's audio samples instead of accumulating; opt out with `Config::clear_audio_on_clock = false`. The five older `clock_*` entry points are deprecated shims rather than removals.
+- *(core)* [**breaking**] Delete the convention-only traits from common.rs - ([61cedf4](https://github.com/lukexor/tetanes/commit/61cedf42a12cfc94537d523fb21d63e40ecba8ee))
+**BREAKING**: the `Clock`, `Reset`, `Regional`, `Sample` and `Sram` traits are gone, and the prelude drops them. `clock`, `reset`, `region`, `set_region`, `output`, `save` and `load` are inherent methods on each component and forward exactly as before, so a call like `deck.cpu_mut().clock()` is unchanged - only the trait import goes away.
+- *(core)* [**breaking**] Delete the pre-page-table memory path - ([9ca8ae6](https://github.com/lukexor/tetanes/commit/9ca8ae64e1c69b267a14621bb0cecb6a1a1ad85a))
+**BREAKING**: `mapper::Banks`, `mapper::BankAccess`, `ppu::CIRam` and the `mem` module are gone. `mem::Memory<D>` is now `memory::Buffer<D>`, and `memory::Memory` is the page-table address space. The `Cart::prg_rom` and `Cart::chr_rom` fields become the `Cart::memory` arena, with `prg_rom()` and `chr_rom()` accessors returning the unpadded bytes. `Ppu::ciram` is gone - nametables are page entries. `Map`'s read hooks lose their `_hook` suffix: `prg_read`, `prg_peek`, `chr_read`, `chr_peek`.
+- *(ppu)* [**breaking**] Hold the PPU registers as fields, not structs - ([145a954](https://github.com/lukexor/tetanes/commit/145a95453b8111839df58840df0ce0529385ea09))
+**BREAKING**: `ppu::ctrl::Ctrl`, `ppu::mask::Mask` and `ppu::status::Status` are gone; read the `ctrl_*`, `mask_*` and `status_*` fields on `Ppu` instead.
+- *(ui)* Follow the debugger accessors, and stop building one to discard it - ([2606f3e](https://github.com/lukexor/tetanes/commit/2606f3e33246a4e65c6f79606fcb1c02344a8758))
+
+
+### 📚 Documentation
+
+- *(core)* Describe the code as it stands, not its history - ([5a5b65b](https://github.com/lukexor/tetanes/commit/5a5b65bddb1a806d113bfa48683f4000a47d9176))
+
+- Correct the supported-mapper table's counts, VRC4f and percentages - ([ebcc66c](https://github.com/lukexor/tetanes/commit/ebcc66c4277ee9866dee457fcf1491804f38de8a))
+- Correct stale facts in CLAUDE.md, the mapper docs and the README table - ([b702137](https://github.com/lukexor/tetanes/commit/b70213730005ffcf5e91b3bc073a1cfe8869ec67))
+- Fix stale references and drop history from the branch's comments - ([97a2850](https://github.com/lukexor/tetanes/commit/97a2850fc67cdd2fdec4a43e16c7519cb1728b7d))
+
+### ⚡ Performance
+
+- *(core)* [**breaking**] Keep the cart's ROM out of save states - ([12156e5](https://github.com/lukexor/tetanes/commit/12156e56b69a12774b37e06ad45772cbf03ed1da))
+**BREAKING**: save states and rewind snapshots no longer carry the cart's ROM, so a state can only be applied to the game it came from. `Cpu::load` and `ControlDeck::load_cpu` are fallible, returning `cpu::StateMismatch` when the state does not belong to the loaded cart.
+- *(rewind)* Re-render rewound frames instead of storing them - ([1ba7f48](https://github.com/lukexor/tetanes/commit/1ba7f48a7f3b8a8f2dc567cab4c9809ef0cbe8a4))
+
+
+### ⚙️ Miscellaneous Tasks
+
+
+- Clear the must_use, const fn and rustdoc warnings - ([5ef3404](https://github.com/lukexor/tetanes/commit/5ef3404c090e5ce564f5a08dd888bc4732060389))
+- Fixed cd - ([0022029](https://github.com/lukexor/tetanes/commit/002202939ed2ed381d8415040fdea4d113dbabc3))
+
+
 ## [0.14.2](https://github.com/lukexor/tetanes/compare/0.14.1..0.14.2) - 2026-06-11
 
 ### 🐛 Bug Fixes


### PR DESCRIPTION



## 🤖 New release

* `tetanes-core`: 0.14.2 -> 0.15.0
* `tetanes`: 0.14.2 -> 0.15.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `tetanes-core`

<blockquote>

## [0.15.0](https://github.com/lukexor/tetanes/compare/0.14.2..0.15.0) - 2026-08-06

### ⛰️  Features

- *(apu)* Add band-limited step synthesis - ([a6f0df0](https://github.com/lukexor/tetanes/commit/a6f0df0edbcb4eb8f905bbe75e38820412f6a5fa))
- *(bench)* TETANES_BENCH_FILTER selects the output filter - ([36b2646](https://github.com/lukexor/tetanes/commit/36b26463ac6bdec04f4f57f9879b4624674fd345))
- *(core)* [**breaking**] One patch table for every kind of cheat - ([5214d3b](https://github.com/lukexor/tetanes/commit/5214d3bf2a7f54a8320ada1d4545814cf07321a8))
**BREAKING**: `Bus::genie_codes` is replaced by `Bus::patches`, and a console state no longer carries cheats.
- *(core)* [**breaking**] Default to a 48 kHz sample rate - ([7f2071a](https://github.com/lukexor/tetanes/commit/7f2071a3e875ee1c750d2ffe77e40e48b4b459e6))
**BREAKING**: `Apu::DEFAULT_SAMPLE_RATE` is 48 kHz, so a deck that does not call `set_sample_rate` produces different samples than before.
- *(core)* Serialize console state into a caller's buffer - ([52e00af](https://github.com/lukexor/tetanes/commit/52e00af6d7876922af707cace6060b7986248c4b))
- *(core)* Add page-based cartridge memory translation - ([398793e](https://github.com/lukexor/tetanes/commit/398793e54fd22944d0a0403eb45cff05bf617bac))
- *(libretro)* Expose the console's memory to the frontend - ([1538183](https://github.com/lukexor/tetanes/commit/1538183b92974582527501009d18689f759b07f3))
- *(mapper)* Add Taito TC0190/TC0350 and TC0690 (Mappers 33, 48) - ([b127fe6](https://github.com/lukexor/tetanes/commit/b127fe62b37edcfd95ed9ed23cbb7822bb60779b))
- *(mapper)* Add VRC2/VRC4 (Mappers 021, 022, 023, 025) - ([6cde160](https://github.com/lukexor/tetanes/commit/6cde1600af04cbe17251ab58ae4be29190b660e1))
- *(mapper)* Report board registers for a debugger pane - ([571d870](https://github.com/lukexor/tetanes/commit/571d87051c513549ece940eb19fee7f046722ab3))
- *(mapper)* Implement MMC5's vertical split screen - ([bdfd9e8](https://github.com/lukexor/tetanes/commit/bdfd9e8f2235dcbef55589660babc852022389cd))
- *(mapper)* [**breaking**] Serve MMC5 from page tables - ([1299ca9](https://github.com/lukexor/tetanes/commit/1299ca91f836945f7f28f1490c84e89762345411))
**BREAKING**: `Exrom::read_ex_ram`, `write_ex_ram`, `rom_select`, `set_prg_bank_range`, `update_prg_banks` and `update_chr_banks` are gone; MMC5 serves its memory from page tables and republishes banking through `Map::update_banks`. `Cart::chr_size` goes with the last board that needed it.
- *(mapper)* Add a PPU read hook for boards that synthesise CHR reads - ([1a0a68e](https://github.com/lukexor/tetanes/commit/1a0a68e648a3a4942af06c963d1fbd68399cab5c))
- *(mapper)* Serve FK23C from page tables - ([98fb652](https://github.com/lukexor/tetanes/commit/98fb6523fc6da2c56209e2219b03ad4625d9c7d4))
- *(mapper)* Serve BandaiFCG from page tables - ([53db1d7](https://github.com/lukexor/tetanes/commit/53db1d78f6a5e0cb5efef722fe0680d03c942135))
- *(mapper)* Serve Namco163 from page tables - ([7e121ec](https://github.com/lukexor/tetanes/commit/7e121eceb453718b69f8c179d43bd9f6791981e6))
- *(mapper)* Serve MMC2 and MMC4 from page tables - ([91aa8c5](https://github.com/lukexor/tetanes/commit/91aa8c5322ffc760e00e2dbe67edab0b8e358d40))
- *(mapper)* Serve NES-EVENT from page tables - ([bde36ff](https://github.com/lukexor/tetanes/commit/bde36ff887ecc64c9a39911fbf3df6f358438568))
- *(mapper)* Serve VRC6 from page tables - ([621acb0](https://github.com/lukexor/tetanes/commit/621acb0a492861d5f9253ec9e5dabd45f2d3db3e))
- *(mapper)* Serve FME7 and Jaleco SS88006 from page tables - ([cd60771](https://github.com/lukexor/tetanes/commit/cd607715a0d39cbdfc3e891b9363de6b4a11978b))
- *(mapper)* [**breaking**] Serve MMC3 from page tables - ([c3af9a0](https://github.com/lukexor/tetanes/commit/c3af9a065f1dad9f4b2d662b09dbc86c421ef2de))
**BREAKING**: `Mmc3::set_chr_banks` is gone, along with the board's own `update_prg_banks`/`update_chr_banks`. MMC3 republishes its banking through `Map::update_banks` from the register file, and four-screen carts allocate 4K of CIRAM rather than a separate `ex_ram` buffer.
- *(mapper)* Serve MMC1 from page tables - ([00a62b4](https://github.com/lukexor/tetanes/commit/00a62b461e034e7a2001e1816e070eee06ad1ae7))
- *(mapper)* Serve tier 3a bank-switchers from page tables - ([9b63b40](https://github.com/lukexor/tetanes/commit/9b63b40efd92f8a48920b639107b3e306a2df0f2))
- *(mapper)* Serve NROM from page tables - ([9e7e71e](https://github.com/lukexor/tetanes/commit/9e7e71e08c1ad1dac3b77d680e3eaba65e51cdf8))


### 🐛 Bug Fixes

- *(apu)* Size the BLEP buffer from the rate it is tuned to - ([8e5179b](https://github.com/lukexor/tetanes/commit/8e5179b7c2ec1c73a9a712c74f879b44731bb2e7))
- *(audio)* Pace on a deadline and hold the buffer with rate control - ([8d27d27](https://github.com/lukexor/tetanes/commit/8d27d27bcb8572e6da5e9c2f46de52c045a6c437))
- *(cart)* Load Dream Master as mapper 210 - ([05fdef3](https://github.com/lukexor/tetanes/commit/05fdef3e82b8a48bf907092e662d151df26c3c55))
- *(cart)* Load Famicom Jump II as mapper 153 - ([ea94174](https://github.com/lukexor/tetanes/commit/ea94174b82616a690c51fa374deda73178d2b311))
- *(cart)* Read the NES 2.0 ram size bytes as two nibbles - ([2110e9f](https://github.com/lukexor/tetanes/commit/2110e9f90093a2f9328271db8eed733f05c9c4db))
- *(cart)* Correct Top Rider's mapper and stop the game db self-referencing - ([fa6098f](https://github.com/lukexor/tetanes/commit/fa6098fcbde1b2ef7b0de558d16decc6ece88a95))
- *(control-deck)* Stop a restored state reverting the player's settings - ([e3b64a8](https://github.com/lukexor/tetanes/commit/e3b64a8295a37f0f2b673b1749d80014a73bcbf1))
- *(control-deck)* Refresh the frame when the console moves without a clock - ([ea4575f](https://github.com/lukexor/tetanes/commit/ea4575f19360afd74aaf0aede47b369b3f087437))
- *(core)* Power-cycle cart RAM on a hard reset - ([9baa46e](https://github.com/lukexor/tetanes/commit/9baa46e4277bf1ca251183215f35c64582ccbada))
- *(core)* [**breaking**] Match a save state to its cart by ROM CRC, not by size - ([52632c2](https://github.com/lukexor/tetanes/commit/52632c233c9ee3d24407129e7aa03ec415218f4d))
**BREAKING**: save states record the cart's ROM CRC32; states written by earlier builds no longer load.
- *(core)* [**breaking**] Hand out one nes frame per clock_frame call - ([7cca0af](https://github.com/lukexor/tetanes/commit/7cca0af3c7cc03a83bdf6ae6329a6b17c8a8c8b3))
**BREAKING**: `ControlDeck::clock_frame` returns `Result<Clocked>` rather than `Result<()>` and clocks at most one NES frame per call; drive it with `while deck.clock_frame()? == Clocked::Continue {}` to clock a whole display frame as before.
- *(core)* Keep the player's settings out of restored states - ([8afede0](https://github.com/lukexor/tetanes/commit/8afede031ebe80fb198d59d41ca566749466435a))
- *(core)* Keep load_bytes on the save version - ([be52911](https://github.com/lukexor/tetanes/commit/be52911a24cecca50c57c857fb668c8ece83408d))
- *(core)* Wrap page offsets within their region - ([fa7f637](https://github.com/lukexor/tetanes/commit/fa7f637a3f1620102fed38c744c46e799614dc0e))
- *(fs)* Report header versions as text - ([7e2795b](https://github.com/lukexor/tetanes/commit/7e2795b496a68cb355fcabc1dc7a4d12f47d86e1))
- *(mapper)* Stop FK23C write-enabling its unmapped WRAM windows - ([e070fde](https://github.com/lukexor/tetanes/commit/e070fded8c58c43ac01bbc7bc54b58388d8b2360))
- *(mapper)* Decode VRC2's mirroring register at all four indices - ([0f5c29f](https://github.com/lukexor/tetanes/commit/0f5c29f29149e0c0ec512c29971f7bdeaef1fc13))
- *(mapper)* Decode FME-7's R:8 select bit - ([878b82e](https://github.com/lukexor/tetanes/commit/878b82eef94ccbfeb2735a88b8d698397480e264))
- *(mapper)* Apply mapper 210's mirroring - ([138f134](https://github.com/lukexor/tetanes/commit/138f13477ab795d9a15b05e914a48ca0aa86bf88))
- *(mapper)* Correct MMC5's split prefetch scroll and $5204 readback - ([7b7b190](https://github.com/lukexor/tetanes/commit/7b7b19017ce352b03eac8155c72945b71f4cfd8e))
- *(mapper)* Let mapper 153 read its own PRG-RAM - ([d53b2db](https://github.com/lukexor/tetanes/commit/d53b2db570740b87e32da4f8514bb85ec5008928))
- *(mapper)* [**breaking**] Tag serialized boards by a stable id, not declaration order - ([8440bb3](https://github.com/lukexor/tetanes/commit/8440bb3335f352a5fc14384b97ff5838fba82702))
**BREAKING**: `Mapper::Fk23C` is no longer boxed, and a mapper number no board serves is now `mapper::Error::Unimplemented` rather than a silent `Mapper::none()` that read as open bus. Tools that survey ROMs rather than run them should use `Cart::from_rom_unmapped`/`Cart::from_path_unmapped`. The on-disk format is byte-for-byte unchanged by this commit.
- *(mapper)* Honour MMC5's sprite-size rule for CHR bank sets - ([4218c4d](https://github.com/lukexor/tetanes/commit/4218c4d5304a219336904e313306366251a36909))
- *(mapper)* Ignore FK23C's CHR-RAM select when the cart has no CHR-RAM - ([69e754f](https://github.com/lukexor/tetanes/commit/69e754f16e3b003af8e56014e1becafdaef8758b))
- *(mapper)* Apply Namco163 nametable select on every board variant - ([0bf93f4](https://github.com/lukexor/tetanes/commit/0bf93f4fa182afab2aecc5d1a01a567d0ebdb8cc))
- *(mapper)* Make VRC6 helpers const - ([79d3766](https://github.com/lukexor/tetanes/commit/79d376696b38010be8b25e18d6c047d4aa64cb27))
- *(mapper)* Restore nametable mirroring in sync, and unpin the game db - ([c47a60c](https://github.com/lukexor/tetanes/commit/c47a60cfbe10b4aad2ffb2218344ad7feb1a82f9))
- *(mapper)* Rebuild page tables when a save state is loaded - ([9de76c8](https://github.com/lukexor/tetanes/commit/9de76c81b9bd34d385e5a7cf4628fb50242c8987))
- *(ppu)* Read the dummy NT bytes on dots 337 and 339 only - ([e38ecb6](https://github.com/lukexor/tetanes/commit/e38ecb6f8ca484cc87ec8e02305ad7b26a6cda90))
- *(ppu)* Stop rotating the palette latches on the dummy NT fetches - ([bd2a8db](https://github.com/lukexor/tetanes/commit/bd2a8dba42e237646bb5f03ef4c3ffbc0e225e13))
- *(ppu)* [**breaking**] Forward the region to the mapper, and box SunsoftFme7 - ([f421867](https://github.com/lukexor/tetanes/commit/f4218677ee52d56004a888db6310cb2673b42fd4))
**BREAKING**: `Mapper::SunsoftFme7` is now boxed. The `boards!` stable ids become each board's primary mapper number, which changes the tag written into save states - riding the same undeployed SAVE_VERSION 2 bump as the rest of this release.
- *(sram)* Back up a save that cannot be read - ([5b2b671](https://github.com/lukexor/tetanes/commit/5b2b671a64fd627c215373e148a2ed712a1b74c1))
- *(sram)* Version battery saves independently of save states - ([7f23d4b](https://github.com/lukexor/tetanes/commit/7f23d4b094b1e312cabe50e6b50fc9ea1b2551f1))
- *(test)* Stop UPDATE_SNAPSHOT clobbering parallel snapshot writes - ([fcb1e0d](https://github.com/lukexor/tetanes/commit/fcb1e0dd54a35c49ed5c6bbeca30021ffb0a2d6d))

- Drop Game Genie codes when the cart is swapped - ([3ae10ff](https://github.com/lukexor/tetanes/commit/3ae10ff924781ca3d4dcb70704ae2fa3bcd49244))

### 🚜 Refactor

- *(core)* [**breaking**] Give a cart's battery one contiguous slice - ([6d3586b](https://github.com/lukexor/tetanes/commit/6d3586b350bdfe34880e4397ca250a26295b07a8))
**BREAKING**: `Map::save_sram`/`load_sram` are replaced by `sync_battery`/`restore_battery`, `MemoryLayout` gains `battery_ext`, and `ControlDeck::sram`/`save_sram` take `&mut self`.
- *(core)* [**breaking**] Take readers and writers, not paths - ([04bc7ae](https://github.com/lukexor/tetanes/commit/04bc7aec2f2ad5a72d35c795b8144890dbdedd37))
**BREAKING**: `fs` and `ControlDeck` save/load now take `Read`/`Write`, the path-taking forms are `*_path`, `fs::load_bytes` is gone since `&[u8]` is already a reader, and `Config::data_dir` is replaced by `Config::sram_dir: Option<PathBuf>`.
- *(core)* [**breaking**] Drop the accessors that only return a public field - ([4c8891d](https://github.com/lukexor/tetanes/commit/4c8891dbaa034a99aab83a4d2ec5a98abd9cfd85))
**BREAKING**: Cart::region, Cart::ram_state, Bus::region, Ppu::region, Apu::region, Dmc::region, Noise::region, Joypad::index, Zapper::x, Zapper::y and Mmc3::irq_pending are removed; read the field of the same name.
- *(core)* Put run-ahead's rewind through the restore funnel - ([4748ffe](https://github.com/lukexor/tetanes/commit/4748ffedb447bf36bb84fde86c8a206166f48894))
- *(core)* [**breaking**] Name the debugger accessors for the one debugger there is - ([1902979](https://github.com/lukexor/tetanes/commit/19029792c850326caa511cca5f0674ce23567ff5))
**BREAKING**: `ControlDeck::add_debugger`/`remove_debugger` are now `set_debugger`/`clear_debugger`, and the latter takes no argument.
- *(core)* [**breaking**] Make memory::Buffer crate-internal - ([9ef4227](https://github.com/lukexor/tetanes/commit/9ef42277d9571d5b65a155f554994ef503a0975d))
**BREAKING**: `memory::Buffer` and its unused constructors are no longer public.
- *(core)* Drop the unused BandLimited accessors - ([9875f48](https://github.com/lukexor/tetanes/commit/9875f481e579daaf95090171b32669abaad8efef))
- *(core)* Move the mapper and debugger bus methods out of ppu.rs - ([b13767e](https://github.com/lukexor/tetanes/commit/b13767e550c839b69a33cd3e070815cfb7ec0c07))
- *(core)* [**breaking**] Consolidate the Bus surface after flattening - ([7afe6cc](https://github.com/lukexor/tetanes/commit/7afe6cc106756d68dd619c703994d3ccb04c07ea))
**BREAKING**: `Input::read`/`Input::peek` are `read_port`/`peek_port` and no longer take a `&Ppu`; `Bus::input_read`/`input_peek` are what read $4016/$4017. `Bus::cpu_bus_read`/`cpu_bus_write`/`cpu_bus_peek` and `ppu_bus_read`/`ppu_bus_write` are now crate-internal; use `Bus::peek`, `Bus::ppu_bus_peek`, `Bus::chr_peek` or `Bus::copy_ppu_bus` to observe.
- *(core)* [**breaking**] Flatten ownership so Bus holds the console - ([c34e8b8](https://github.com/lukexor/tetanes/commit/c34e8b883817bb2d882ec4dd26600d0dcabc45de))
**BREAKING**: `ControlDeck::cpu()` returns registers only; the console is `ControlDeck::bus()`, and save states, rewind and replay are now `Bus` rather than `Cpu`. `ControlDeck::load_cpu` is `load_bus`. `Mapper` and `Memory` moved from `Ppu` to `Bus`, as did the debugger. `PpuDebugger` is `Debugger` and its callback takes `&Bus`. `Ppu::load_nametables`/`load_pattern_tables`/`load_oam` take the CHR window to read from. The `memory::Read` and `memory::Write` traits are removed in favor of inherent methods. Save states from earlier builds will not load.
- *(core)* [**breaking**] Make video::Frame a fixed-size buffer - ([b79a2fe](https://github.com/lukexor/tetanes/commit/b79a2fefc16376587eb8c2f044f3583bcd43789b))
**BREAKING**: `video::Frame` no longer derefs to `Vec<u8>`. Callers using it as a `Vec` should use `as_slice`, `as_array`, or indexing; callers that resized it have no replacement, as the size is now part of the type.
- *(core)* [**breaking**] Collapse the clocking API and clean up public surface - ([2b4fd1e](https://github.com/lukexor/tetanes/commit/2b4fd1eb4e4b102c9342f4d42a75d6eff077e1e7))
**BREAKING**: MSRV is now 1.88; 1.85 could not build the crate at all. `Map::sync` is `Map::update_banks`, `Ppu::sync_mapper` is `Ppu::rebuild_mapper_state`, and MMC5's colliding `update_chr_banks` is `select_chr_set`. Frame buffers are fixed-size: `Ppu::frame_buffer` and `ControlDeck::frame_buffer_raw` return `&[u16; ppu::size::FRAME]`, `ControlDeck::frame_buffer` returns `&[u8; Frame::SIZE]`, and `frame_buffer_into` takes `&mut [u8; Frame::SIZE]`. `ControlDeck::apu_mut` returns `&mut Apu`, `joypad` takes `&self`, and `wram` returns `&[u8; bus::size::WRAM]`. Clocking clears the previous call's audio samples instead of accumulating; opt out with `Config::clear_audio_on_clock = false`. The five older `clock_*` entry points are deprecated shims rather than removals.
- *(core)* [**breaking**] Delete the convention-only traits from common.rs - ([61cedf4](https://github.com/lukexor/tetanes/commit/61cedf42a12cfc94537d523fb21d63e40ecba8ee))
**BREAKING**: the `Clock`, `Reset`, `Regional`, `Sample` and `Sram` traits are gone, and the prelude drops them. `clock`, `reset`, `region`, `set_region`, `output`, `save` and `load` are inherent methods on each component and forward exactly as before, so a call like `deck.cpu_mut().clock()` is unchanged - only the trait import goes away.
- *(core)* [**breaking**] Delete the four single-purpose traits - ([9e9bee0](https://github.com/lukexor/tetanes/commit/9e9bee0bf45f8f2cdd21eca976d89def65fec105))
**BREAKING**: the `PpuAddr`, `InputRegisters`, `TimerCycle` and `Consume` traits are gone. `PpuAddr` becomes the free functions `ppu::is_attr` and `ppu::is_palette`; the rest become inherent methods on the types that had the impls.
- *(core)* [**breaking**] Delete the pre-page-table memory path - ([9ca8ae6](https://github.com/lukexor/tetanes/commit/9ca8ae64e1c69b267a14621bb0cecb6a1a1ad85a))
**BREAKING**: `mapper::Banks`, `mapper::BankAccess`, `ppu::CIRam` and the `mem` module are gone. `mem::Memory<D>` is now `memory::Buffer<D>`, and `memory::Memory` is the page-table address space. The `Cart::prg_rom` and `Cart::chr_rom` fields become the `Cart::memory` arena, with `prg_rom()` and `chr_rom()` accessors returning the unpadded bytes. `Ppu::ciram` is gone - nametables are page entries. `Map`'s read hooks lose their `_hook` suffix: `prg_read`, `prg_peek`, `chr_read`, `chr_peek`.
- *(mapper)* Drop unused VRC6 nametable setters and MMC3 chr_window - ([1354e7a](https://github.com/lukexor/tetanes/commit/1354e7a3439a7219a9d05fcb725e993da680289f))
- *(mapper)* Match the documented polarity of mapper 071's mirroring bit - ([421acec](https://github.com/lukexor/tetanes/commit/421acec6f78d01c1696ec56eed14e686dd821b01))
- *(mapper)* Generate the per-board plumbing from one boards! table - ([c872dd9](https://github.com/lukexor/tetanes/commit/c872dd96e58841e07f0be91ea7c07e15add9752e))
- *(mapper)* [**breaking**] Give Map every method a board needs, drop the supertraits - ([7a6439a](https://github.com/lukexor/tetanes/commit/7a6439a9968a3702b607e46ff3c2b4d14d8838d1))
**BREAKING**: `Map` no longer requires `Clock + Regional + Reset + Sram`. `clock`, `reset`, `region` and `set_region` are defaulted methods on `Map` itself, and `impl Map for Mapper` becomes inherent methods on `Mapper`, so `Map` no longer needs importing to call them.
- *(mapper)* [**breaking**] Unify per-board dispatch flags into MapperOps - ([8abfaee](https://github.com/lukexor/tetanes/commit/8abfaee32986e65a33873b5d775835b94bd27ac7))
**BREAKING**: `Map::watches_ppu_bus`, `Map::serves_prg_reads` and `Map::serves_chr_reads` are replaced by a single `Map::mapper_ops` returning `MapperOps` bitflags, which also declares `CLOCKED`, `IRQ`, `AUDIO` and `DMA`. A board that does not declare a hook no longer has it called.
- *(ppu)* Derive fine Y from v instead of caching it - ([c44bca0](https://github.com/lukexor/tetanes/commit/c44bca0954ab346511f811232ad8a3fb188f518f))
- *(ppu)* [**breaking**] Hold the PPU registers as fields, not structs - ([145a954](https://github.com/lukexor/tetanes/commit/145a95453b8111839df58840df0ce0529385ea09))
**BREAKING**: `ppu::ctrl::Ctrl`, `ppu::mask::Mask` and `ppu::status::Status` are gone; read the `ctrl_*`, `mask_*` and `status_*` fields on `Ppu` instead.


### 📚 Documentation

- *(bench)* Rewrite the benchmark README around running it - ([84357fc](https://github.com/lukexor/tetanes/commit/84357fc5acfa1e252c362cb72fa8a20f09cb2d6a))
- *(bench)* Record Raspberry Pi 5 on-target results - ([fae0367](https://github.com/lukexor/tetanes/commit/fae0367be3de371e15839c7eb12bbddfccbdcb2a))
- *(bench)* Decline the MesenCE sprite-shifter port with reasons - ([89fa791](https://github.com/lukexor/tetanes/commit/89fa7912a2fef619d12194327e120c5ff3d1a58e))
- *(bench)* Scope the two-layout rule to perf verdicts, record fine_y and dummy-fetch results - ([b2e26d8](https://github.com/lukexor/tetanes/commit/b2e26d8dd1a9aaf7e5382e664c2a948937603808))
- *(bench)* Record the dispatch-reshape layout draw - ([96ef17a](https://github.com/lukexor/tetanes/commit/96ef17ac67fb22c35ddc39a6e179f21b1b1a8c77))
- *(bench)* Record the shifter-reload layout result - ([54e6b4d](https://github.com/lukexor/tetanes/commit/54e6b4d02f5c31a3835606a32a7411430103dde4))
- *(bench)* Measure candidates at two code layouts - ([f8e4282](https://github.com/lukexor/tetanes/commit/f8e4282e1b67c357c204fb993024978aae5ec048))
- *(bench)* Correct profile shares read from the wrong denominator - ([4166301](https://github.com/lukexor/tetanes/commit/416630137aaa520e1dda59193d9dd2e505180009))
- *(bench)* Correct the boxing conclusion with FME7 ROMs measured - ([97e5da7](https://github.com/lukexor/tetanes/commit/97e5da7c8541af1ed519ce7718f211b55a5bdf02))
- *(bench)* Record the trait-diet and boards! table results - ([c07971d](https://github.com/lukexor/tetanes/commit/c07971d5b604d03d3b9eb0a5f332046717b9be23))
- *(bench)* Record the MapperOps results and correct the catch-up conclusion - ([13cae45](https://github.com/lukexor/tetanes/commit/13cae459c7ec7db8290b85b715245006af2f1e24))
- *(bench)* Record the PPU results and the catch-up investigation - ([9fe62c0](https://github.com/lukexor/tetanes/commit/9fe62c00be75133b816f164dedb40b46ddf2c5c2))
- *(bench)* Record the frame times after deleting the old memory path - ([17596d1](https://github.com/lukexor/tetanes/commit/17596d1defc5c10c040cceeac4e7b85e317210a8))
- *(bench)* Record frame times after the mapper rework - ([3968038](https://github.com/lukexor/tetanes/commit/396803876b50d0a4fd5aa1b05ef9222ed9ff042b))
- *(core)* Correct the mapper, PPU peek and Bus-state docs - ([dfb4207](https://github.com/lukexor/tetanes/commit/dfb420739d1ec2529023265b4dfc104426bcd35d))
- *(core)* Correct stale board, filter and audio-profile references - ([fff8802](https://github.com/lukexor/tetanes/commit/fff880262c7cb9cc320fd32881b15861bc05da23))
- *(core)* Describe the code as it stands, not its history - ([5a5b65b](https://github.com/lukexor/tetanes/commit/5a5b65bddb1a806d113bfa48683f4000a47d9176))
- *(core)* Turn on missing_docs and say which half is API - ([4511ddf](https://github.com/lukexor/tetanes/commit/4511ddfc0981fa6a2309ec4bf37c05f352a55b75))
- *(mapper)* Link the save-state rebuild to Bus, not Ppu - ([3e24c14](https://github.com/lukexor/tetanes/commit/3e24c14c8def4e428f44b7312af94bba73a409c9))
- *(mapper)* Correct what FK23C's $A001 handler relies on - ([5e2a93e](https://github.com/lukexor/tetanes/commit/5e2a93eb6fe417366205318730555ea5e95c2129))
- *(mapper)* Record that Color Dreams boards have no bus conflicts - ([fceecca](https://github.com/lukexor/tetanes/commit/fceecca4ff9104f2cf374a29fa15c52a5daf4491))
- *(mapper)* Drop the transitional phrasing from the Map trait - ([ac1725d](https://github.com/lukexor/tetanes/commit/ac1725ddebd4d49e367a5e7dced12cca4b09d223))
- *(memory)* Say why the region wrap is a divide - ([878c8d0](https://github.com/lukexor/tetanes/commit/878c8d0580677710e2fbcbc7372d20c8050b622c))

- Correct stale facts in CLAUDE.md, the mapper docs and the README table - ([b702137](https://github.com/lukexor/tetanes/commit/b70213730005ffcf5e91b3bc073a1cfe8869ec67))
- Fix stale references and drop history from the branch's comments - ([97a2850](https://github.com/lukexor/tetanes/commit/97a2850fc67cdd2fdec4a43e16c7519cb1728b7d))

### ⚡ Performance

- *(apu)* [**breaking**] Synthesise the output from channel deltas - ([cb9a45b](https://github.com/lukexor/tetanes/commit/cb9a45b3c091e84a3c613010dfb9dd256cb85a8a))
**BREAKING**: `Apu::sample_period`, `Apu::sample_counter` and `Apu::mapper_outputs` are gone, along with `apu::filter`'s `Fir`, `windowed_sinc_kernel` and the decimation half of `FilterChain`.
- *(apu)* Run the channels between waveform steps, not every cycle - ([9b9699c](https://github.com/lukexor/tetanes/commit/9b9699c46de7bfbe319af9a2d75797a90b97d48d))
- *(apu)* Flush denormals and mix only when the filter chain samples - ([9934043](https://github.com/lukexor/tetanes/commit/99340432488e0ed8ac6fca9b1abb726eb920ffc1))
- *(apu)* [**breaking**] Run the filter chain at two rates instead of six - ([fa2966e](https://github.com/lukexor/tetanes/commit/fa2966eaf00b605cd2ae58497615936222228853))
**BREAKING**: `apu::filter::Filter`, `apu::filter::SampledFilter` and `FilterKind::Identity` are removed, and `FilterChain`'s fields are now the named stages rather than a `[SampledFilter; 6]`, which changes the save-state layout - covered by the `SAVE_VERSION` bump already on this branch.
- *(apu)* Mix from integer channel levels in the MMC5 hot path - ([31186ed](https://github.com/lukexor/tetanes/commit/31186edb5b74ad3e97dcbd0fbfda36b73ef1ff1d))
- *(apu)* Avoid a libm call in the FIR filter hot loop - ([f91f59e](https://github.com/lukexor/tetanes/commit/f91f59ef780b9e0e258223ba66f604c075384e08))
- *(core)* Snapshot run-ahead into last frame's console - ([42e9378](https://github.com/lukexor/tetanes/commit/42e9378f06ffe76bc7069f61c502a21c15cab045))
- *(core)* Snapshot run-ahead with a clone instead of bincode - ([605f917](https://github.com/lukexor/tetanes/commit/605f91721346daf39356d28cbe90bb5f143e6449))
- *(core)* [**breaking**] Keep the cart's ROM out of save states - ([12156e5](https://github.com/lukexor/tetanes/commit/12156e56b69a12774b37e06ad45772cbf03ed1da))
**BREAKING**: save states and rewind snapshots no longer carry the cart's ROM, so a state can only be applied to the game it came from. `Cpu::load` and `ControlDeck::load_cpu` are fallible, returning `cpu::StateMismatch` when the state does not belong to the loaded cart.
- *(core)* Hoist per-pixel invariants in the NTSC filter - ([bf6dd6e](https://github.com/lukexor/tetanes/commit/bf6dd6e97a2d8140fafe0aa8d144f1b3e6eb956f))
- *(core)* Un-box Ppu::sprites; document why wram/frame buffer stay boxed - ([5fac025](https://github.com/lukexor/tetanes/commit/5fac025c4c53306c1e462bd909d4e79841a0113d))
- *(core)* Split Ppu::clock's branch chain and flag-gate the debugger - ([8656742](https://github.com/lukexor/tetanes/commit/8656742657df18de24d128bdd4f4bc4ff52734ae))
- *(mapper)* Re-bank only on writes that change banking - ([f1d6f9a](https://github.com/lukexor/tetanes/commit/f1d6f9a10cd0a76098c6b4f079d29a96600ea4e6))
- *(mapper)* Only re-map the CHR window MMC2/MMC4's latch changed - ([5b2371a](https://github.com/lukexor/tetanes/commit/5b2371a41fe9877d43bbc9ac39a130d173b8f4b0))
- *(ppu)* Reload BG shifters only on real tile fetches - ([82ad8af](https://github.com/lukexor/tetanes/commit/82ad8afea77fd7b84de6087864de03c09886bf0a))
- *(ppu)* Gate the pixel path on a dot threshold, not on mask flags - ([41d8ea5](https://github.com/lukexor/tetanes/commit/41d8ea577b3a551ecf34ea679d5f5bf3ff2a2ee1))
- *(ppu)* Fold greyscale and emphasis in by the run, not per pixel - ([71b7ff1](https://github.com/lukexor/tetanes/commit/71b7ff106abfcc43d17ae9b5571d57ad7d9d1e13))
- *(ppu)* Visit only the sprites covering a dot - ([341f832](https://github.com/lukexor/tetanes/commit/341f83208885b819067c07e10867b23e1ae68820))
- *(video)* [**breaking**] Bake the NTSC palette at build time - ([830b850](https://github.com/lukexor/tetanes/commit/830b850da01eee5c9fd683d030c72a6c833d0ae5))
**BREAKING**: `video::NTSC_PALETTE` is a `&'static [u8; N]` of red, green, blue triples baked in at build time, not a `OnceLock<Vec<u32>>` packing each color into one `u32`.
- *(wasm)* Store local-storage payloads as base64, not json arrays - ([abb4488](https://github.com/lukexor/tetanes/commit/abb44881dfc258ede42689ef50517c9cc7b99d0d))


### 🧪 Testing

- *(apu)* Assert audio with a coarse profile instead of a sample hash - ([e411661](https://github.com/lukexor/tetanes/commit/e4116615f5ee744c708e05b3e4e5148346bc4127))
- *(core)* Implement the bus routing tests and drop the two unassertable ROMs - ([dc60b4b](https://github.com/lukexor/tetanes/commit/dc60b4b178e1f7e1f64df16b28a2e0bb3f24065d))
- *(core)* Assert blargg result codes and report tones instead of ignoring - ([5c2e4e6](https://github.com/lukexor/tetanes/commit/5c2e4e6906979ffed444d4041dc3d4ecb1d2cab9))
- *(core)* Cover the save-state and SRAM round trips - ([1b8c0d8](https://github.com/lukexor/tetanes/commit/1b8c0d8fde247d81e0ab9d88f7fe67f11c01cd98))
- *(input)* Assert the zapper through the channel each ROM reports on - ([c483467](https://github.com/lukexor/tetanes/commit/c4834678f9c9ff2feb17a3941e94693f7bcd3d2f))
- *(mapper)* Make the board tests take the bus's route - ([e260d05](https://github.com/lukexor/tetanes/commit/e260d0584decaffbaf8cf5c87b11329c5bbfb963))
- *(mapper)* Cover the last 13 boards in the table - ([9a113c3](https://github.com/lukexor/tetanes/commit/9a113c377c771ddada1efeda8a83722eeab44a00))
- *(mapper)* Cover Jaleco SS88006, Bandai FCG and FK23C - ([a63ddf8](https://github.com/lukexor/tetanes/commit/a63ddf8a9f0a6f144fe0d518472ddbde52d30682))
- *(mapper)* Cover Namco163, Sunsoft FME7 and MMC1 banking and IRQs - ([32ea7dc](https://github.com/lukexor/tetanes/commit/32ea7dcd1f9473e50851f4ba729cac0a53185581))
- *(mapper)* Cover the VRC IRQ counter and VRC6, fixing two overflow panics - ([e42aebf](https://github.com/lukexor/tetanes/commit/e42aebfae551ec84095db8d733e8981d14fdfb63))
- *(ppu)* Assert the field placement the dot loop depends on - ([b063118](https://github.com/lukexor/tetanes/commit/b063118e621843bb1c4ff32d40c6b96c106d337f))


### ⚙️ Miscellaneous Tasks

- *(bench)* Allow sweeping a ROM library for load and clock failures - ([a12c552](https://github.com/lukexor/tetanes/commit/a12c552eb4c0578128c72d342989525b2f8491f4))
- *(bench)* Benchmark a ROM corpus and report variance - ([2d9452e](https://github.com/lukexor/tetanes/commit/2d9452e04c121ecb160fc3e3024f19f64003c409))

- Clear the must_use, const fn and rustdoc warnings - ([5ef3404](https://github.com/lukexor/tetanes/commit/5ef3404c090e5ce564f5a08dd888bc4732060389))
</blockquote>

## `tetanes`

<blockquote>

## [0.15.0](https://github.com/lukexor/tetanes/compare/0.14.2..0.15.0) - 2026-08-06

### ⛰️  Features

- *(mapper)* Add Taito TC0190/TC0350 and TC0690 (Mappers 33, 48) - ([b127fe6](https://github.com/lukexor/tetanes/commit/b127fe62b37edcfd95ed9ed23cbb7822bb60779b))
- *(mapper)* Serve tier 3a bank-switchers from page tables - ([9b63b40](https://github.com/lukexor/tetanes/commit/9b63b40efd92f8a48920b639107b3e306a2df0f2))


### 🐛 Bug Fixes

- *(audio)* Ramp the output in and out instead of cutting - ([5d25e83](https://github.com/lukexor/tetanes/commit/5d25e8367dd4b33abb6db405229cd512ea139fde))
- *(audio)* Pace on a deadline and hold the buffer with rate control - ([8d27d27](https://github.com/lukexor/tetanes/commit/8d27d27bcb8572e6da5e9c2f46de52c045a6c437))
- *(audio)* Prime the output stream before it starts consuming - ([e67a133](https://github.com/lukexor/tetanes/commit/e67a13383ad42293c240219cf564e96e62a86e08))
- *(core)* [**breaking**] Hand out one nes frame per clock_frame call - ([7cca0af](https://github.com/lukexor/tetanes/commit/7cca0af3c7cc03a83bdf6ae6329a6b17c8a8c8b3))
**BREAKING**: `ControlDeck::clock_frame` returns `Result<Clocked>` rather than `Result<()>` and clocks at most one NES frame per call; drive it with `while deck.clock_frame()? == Clocked::Continue {}` to clock a whole display frame as before.
- *(input)* Add enter/shift defaults for start/select - ([68776d2](https://github.com/lukexor/tetanes/commit/68776d2ba8346c44a3ed91e34c1d554f23ae2cbe))
- *(input)* Stop bindings colliding and buttons sticking - ([d2a6bf7](https://github.com/lukexor/tetanes/commit/d2a6bf7a475fbf0733fd4965a16b716e15998591))
- *(input)* Fixed shortcuts to be on press instead of on release - ([099462f](https://github.com/lukexor/tetanes/commit/099462f1839a3ccc78de824780b0ccb52672613d))
- *(input)* Fixed modifier rolling and stuck joypad keys - ([568023c](https://github.com/lukexor/tetanes/commit/568023cae3364a227238497b7d87906d216c1f7f))
- *(libretro)* Six defects found in review, and the claims that hid them - ([28b97dd](https://github.com/lukexor/tetanes/commit/28b97dd8856f3d81ab25071df9d2d076f740a493))
- *(ppu-viewer)* Fixed oam tab zoom - ([f150119](https://github.com/lukexor/tetanes/commit/f150119ab51fc413ea6e02b8e2edcd4ae9fc9a31))
- *(preferences)* Fixed game-genie entry closing when focused in menu - ([2e4b9d6](https://github.com/lukexor/tetanes/commit/2e4b9d64e3222fc0baec1ed32c3dd3bb92dbe5b8))
- *(renderer)* Sync wgpu surface to window size so menu clicks land - ([a39fede](https://github.com/lukexor/tetanes/commit/a39fede957b41be6e494bbeed5a446289dbc3dc6))
- *(rewind)* Render every rewound frame below 1x - ([ae4d19b](https://github.com/lukexor/tetanes/commit/ae4d19b0c75e741c9bd9d1a97b36d987ce3c30c8))

- Drop Game Genie codes when the cart is swapped - ([3ae10ff](https://github.com/lukexor/tetanes/commit/3ae10ff924781ca3d4dcb70704ae2fa3bcd49244))

### 🚜 Refactor

- *(core)* [**breaking**] Take readers and writers, not paths - ([04bc7ae](https://github.com/lukexor/tetanes/commit/04bc7aec2f2ad5a72d35c795b8144890dbdedd37))
**BREAKING**: `fs` and `ControlDeck` save/load now take `Read`/`Write`, the path-taking forms are `*_path`, `fs::load_bytes` is gone since `&[u8]` is already a reader, and `Config::data_dir` is replaced by `Config::sram_dir: Option<PathBuf>`.
- *(core)* [**breaking**] Flatten ownership so Bus holds the console - ([c34e8b8](https://github.com/lukexor/tetanes/commit/c34e8b883817bb2d882ec4dd26600d0dcabc45de))
**BREAKING**: `ControlDeck::cpu()` returns registers only; the console is `ControlDeck::bus()`, and save states, rewind and replay are now `Bus` rather than `Cpu`. `ControlDeck::load_cpu` is `load_bus`. `Mapper` and `Memory` moved from `Ppu` to `Bus`, as did the debugger. `PpuDebugger` is `Debugger` and its callback takes `&Bus`. `Ppu::load_nametables`/`load_pattern_tables`/`load_oam` take the CHR window to read from. The `memory::Read` and `memory::Write` traits are removed in favor of inherent methods. Save states from earlier builds will not load.
- *(core)* [**breaking**] Make video::Frame a fixed-size buffer - ([b79a2fe](https://github.com/lukexor/tetanes/commit/b79a2fefc16376587eb8c2f044f3583bcd43789b))
**BREAKING**: `video::Frame` no longer derefs to `Vec<u8>`. Callers using it as a `Vec` should use `as_slice`, `as_array`, or indexing; callers that resized it have no replacement, as the size is now part of the type.
- *(core)* [**breaking**] Collapse the clocking API and clean up public surface - ([2b4fd1e](https://github.com/lukexor/tetanes/commit/2b4fd1eb4e4b102c9342f4d42a75d6eff077e1e7))
**BREAKING**: MSRV is now 1.88; 1.85 could not build the crate at all. `Map::sync` is `Map::update_banks`, `Ppu::sync_mapper` is `Ppu::rebuild_mapper_state`, and MMC5's colliding `update_chr_banks` is `select_chr_set`. Frame buffers are fixed-size: `Ppu::frame_buffer` and `ControlDeck::frame_buffer_raw` return `&[u16; ppu::size::FRAME]`, `ControlDeck::frame_buffer` returns `&[u8; Frame::SIZE]`, and `frame_buffer_into` takes `&mut [u8; Frame::SIZE]`. `ControlDeck::apu_mut` returns `&mut Apu`, `joypad` takes `&self`, and `wram` returns `&[u8; bus::size::WRAM]`. Clocking clears the previous call's audio samples instead of accumulating; opt out with `Config::clear_audio_on_clock = false`. The five older `clock_*` entry points are deprecated shims rather than removals.
- *(core)* [**breaking**] Delete the convention-only traits from common.rs - ([61cedf4](https://github.com/lukexor/tetanes/commit/61cedf42a12cfc94537d523fb21d63e40ecba8ee))
**BREAKING**: the `Clock`, `Reset`, `Regional`, `Sample` and `Sram` traits are gone, and the prelude drops them. `clock`, `reset`, `region`, `set_region`, `output`, `save` and `load` are inherent methods on each component and forward exactly as before, so a call like `deck.cpu_mut().clock()` is unchanged - only the trait import goes away.
- *(core)* [**breaking**] Delete the pre-page-table memory path - ([9ca8ae6](https://github.com/lukexor/tetanes/commit/9ca8ae64e1c69b267a14621bb0cecb6a1a1ad85a))
**BREAKING**: `mapper::Banks`, `mapper::BankAccess`, `ppu::CIRam` and the `mem` module are gone. `mem::Memory<D>` is now `memory::Buffer<D>`, and `memory::Memory` is the page-table address space. The `Cart::prg_rom` and `Cart::chr_rom` fields become the `Cart::memory` arena, with `prg_rom()` and `chr_rom()` accessors returning the unpadded bytes. `Ppu::ciram` is gone - nametables are page entries. `Map`'s read hooks lose their `_hook` suffix: `prg_read`, `prg_peek`, `chr_read`, `chr_peek`.
- *(ppu)* [**breaking**] Hold the PPU registers as fields, not structs - ([145a954](https://github.com/lukexor/tetanes/commit/145a95453b8111839df58840df0ce0529385ea09))
**BREAKING**: `ppu::ctrl::Ctrl`, `ppu::mask::Mask` and `ppu::status::Status` are gone; read the `ctrl_*`, `mask_*` and `status_*` fields on `Ppu` instead.
- *(ui)* Follow the debugger accessors, and stop building one to discard it - ([2606f3e](https://github.com/lukexor/tetanes/commit/2606f3e33246a4e65c6f79606fcb1c02344a8758))


### 📚 Documentation

- *(core)* Describe the code as it stands, not its history - ([5a5b65b](https://github.com/lukexor/tetanes/commit/5a5b65bddb1a806d113bfa48683f4000a47d9176))

- Correct the supported-mapper table's counts, VRC4f and percentages - ([ebcc66c](https://github.com/lukexor/tetanes/commit/ebcc66c4277ee9866dee457fcf1491804f38de8a))
- Correct stale facts in CLAUDE.md, the mapper docs and the README table - ([b702137](https://github.com/lukexor/tetanes/commit/b70213730005ffcf5e91b3bc073a1cfe8869ec67))
- Fix stale references and drop history from the branch's comments - ([97a2850](https://github.com/lukexor/tetanes/commit/97a2850fc67cdd2fdec4a43e16c7519cb1728b7d))

### ⚡ Performance

- *(core)* [**breaking**] Keep the cart's ROM out of save states - ([12156e5](https://github.com/lukexor/tetanes/commit/12156e56b69a12774b37e06ad45772cbf03ed1da))
**BREAKING**: save states and rewind snapshots no longer carry the cart's ROM, so a state can only be applied to the game it came from. `Cpu::load` and `ControlDeck::load_cpu` are fallible, returning `cpu::StateMismatch` when the state does not belong to the loaded cart.
- *(rewind)* Re-render rewound frames instead of storing them - ([1ba7f48](https://github.com/lukexor/tetanes/commit/1ba7f48a7f3b8a8f2dc567cab4c9809ef0cbe8a4))


### ⚙️ Miscellaneous Tasks


- Clear the must_use, const fn and rustdoc warnings - ([5ef3404](https://github.com/lukexor/tetanes/commit/5ef3404c090e5ce564f5a08dd888bc4732060389))
- Fixed cd - ([0022029](https://github.com/lukexor/tetanes/commit/002202939ed2ed381d8415040fdea4d113dbabc3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).