### PR TITLE
fix(renderer): sync wgpu surface to window size so menu clicks land

### DIFF
--- a/tetanes/src/nes/renderer.rs
+++ b/tetanes/src/nes/renderer.rs
@@ -1176,11 +1176,18 @@ impl Renderer {
                 return Ok(());
             };
 
+            // Pass the size egui used for layout (`inner_size()`) so the painter
+            // can reconcile its surface to it before rendering. They can drift
+            // under Wayland fractional scaling, which stretches the UI and makes
+            // pointer hit-tests miss; see `Painter::paint`.
+            let inner_size = window.inner_size();
+
             let clipped_primitives = self.ctx.tessellate(output.shapes, output.pixels_per_point);
 
             window.pre_present_notify();
             self.painter.borrow_mut().paint(
                 viewport_id,
+                inner_size,
                 output.pixels_per_point,
                 &clipped_primitives,
                 &output.textures_delta,

--- a/tetanes/src/nes/renderer/painter.rs
+++ b/tetanes/src/nes/renderer/painter.rs
@@ -170,6 +170,7 @@ impl Painter {
     pub fn paint(
         &mut self,
         viewport_id: ViewportId,
+        target_size: PhysicalSize<u32>,
         pixels_per_point: f32,
         clipped_primitives: &[epaint::ClippedPrimitive],
         textures_delta: &epaint::textures::TexturesDelta,
@@ -180,6 +181,19 @@ impl Painter {
         let Some(surface) = self.surfaces.get_mut(&viewport_id) else {
             return;
         };
+
+        // Resize the surface to egui's layout size (`inner_size()`). On Wayland a
+        // `request_inner_size()` can resize the window without a `Resized` event,
+        // leaving the surface stale, which stretches the UI and breaks hit-testing.
+        // A zero target (minimized window) keeps the current size.
+        if let (Some(width), Some(height)) = (
+            NonZeroU32::new(target_size.width),
+            NonZeroU32::new(target_size.height),
+        ) && (surface.width != width.get() || surface.height != height.get())
+        {
+            tracing::debug!("reconciling stale surface to {target_size:?}");
+            render_state.resize_surface(surface, width, height);
+        }
 
         let mut encoder =
             render_state


### PR DESCRIPTION
On Wayland with fractional scaling, menu and Save Slot clicks selected the wrong entry, and the offset grew toward the bottom of each menu.

egui lays out and hit-tests in the window's `inner_size()`, while the painter renders into the wgpu surface. The surface is only resized on `WindowEvent::Resized`, but a `request_inner_size()` (sent when the menu-bar height changes) updates `inner_size()` without emitting a `Resized` on Wayland. The surface kept its old size, so the UI rendered stretched relative to egui's layout and the pointer resolved higher than the cursor, by a factor that grows with distance from the top.

eframe (via egui-wgpu) keeps the surface configured to the window's current `inner_size()` instead of relying only on resize events, so it never drifts from what egui laid out. TetaNES removed egui-wgpu and egui-winit in #315 and carries its own integration, so it has to reproduce that step: pass the layout size into `Painter::paint` and resize the surface there before rendering.